### PR TITLE
poetry: make it manylinux compatible

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -2,6 +2,16 @@ self: super: {
 
   poetry2nix = import ./default.nix { pkgs = self; poetry = self.poetry; };
 
-  poetry = super.callPackage ./pkgs/poetry { python = self.python3; };
+  poetry = let
+    # Ensure we're manylinux compatible.
+    # https://github.com/NixOS/nixpkgs/issues/71935
+    python = (super.python3.overrideAttrs(oldAttrs: {
+      postFixup = ''
+        rm $out/lib/${python.libPrefix}/_manylinux.py
+      '';
+    })).override {
+      self = python;
+    };
+  in super.callPackage ./pkgs/poetry { inherit python; };
 
 }


### PR DESCRIPTION
By having the python used for poetry manylinux compatible, it becomes
easier to create lock files in case of extension modules.

The Nixpkgs Python interpreters need to improve on this front, but until
then let's just override them and force compatibility.

https://github.com/NixOS/nixpkgs/issues/71935