### PR TITLE
Fix small mistake in override of vose-alias-method

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -460,7 +460,7 @@ self: super:
     }
   );
 
-  vose-alias-method = super.pytest-datadir.overrideAttrs (
+  vose-alias-method = super.vose-alias-method.overrideAttrs (
     old: {
       postInstall = ''
         rm -f $out/LICENSE


### PR DESCRIPTION
I think this was a copy-paste oversight.