### PR TITLE
Expose mkPoetryPackages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -247,7 +247,7 @@ let
 
 in
 {
-  inherit mkPoetryEnv mkPoetryApplication cli doc;
+  inherit mkPoetryEnv mkPoetryApplication mkPoetryPackages cli doc;
 
   /*
   The default list of poetry2nix override overlays


### PR DESCRIPTION
This function is a useful building block when the Python packages
generated are used for another purpose.