### PR TITLE
Provide withDefaults and withoutDefaults

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -261,4 +261,25 @@ in
     in
       defaultSet // customSet;
   };
+
+  /*
+  Convenience functions for specifying overlays with or without the poerty2nix default overrides
+  */
+  overrides = {
+    /*
+    Returns the specified overlay in a list
+    */
+    withoutDefaults = overlay: [
+      overlay
+    ];
+
+    /*
+    Returns the specified overlay and returns a list
+    combining it with poetry2nix default overrides
+    */
+    withDefaults = overlay: [
+      defaultPoetryOverrides
+      overlay
+    ];
+  };
 }

--- a/tests/git-deps-pinned/default.nix
+++ b/tests/git-deps-pinned/default.nix
@@ -6,9 +6,7 @@ poetry2nix.mkPoetryApplication {
   poetrylock = ./poetry.lock;
   src = lib.cleanSource ./.;
 
-  overrides = [
-    poetry2nix.defaultPoetryOverrides
-    (import ./poetry-git-overlay.nix { inherit pkgs; })
-  ];
+  overrides = poetry2nix.overrides.withDefaults
+    (import ./poetry-git-overlay.nix { inherit pkgs; });
 
 }

--- a/tests/override-support/default.nix
+++ b/tests/override-support/default.nix
@@ -6,8 +6,7 @@ let
     src = ./.;
     poetrylock = ./poetry.lock;
     pyproject = ./pyproject.toml;
-    overrides = [
-      poetry2nix.defaultPoetryOverrides
+    overrides = poetry2nix.overrides.withDefaults
       (
         self: super: {
           alembic = super.alembic.overrideAttrs (
@@ -16,8 +15,7 @@ let
             }
           );
         }
-      )
-    ];
+      );
   };
 in
 runCommand "test" {} ''

--- a/tests/prefer-wheel/default.nix
+++ b/tests/prefer-wheel/default.nix
@@ -6,8 +6,7 @@ let
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     src = lib.cleanSource ./.;
-    overrides = [
-      poetry2nix.defaultPoetryOverrides
+    overrides = poetry2nix.overrides.withDefaults
       # This is also in overrides.nix but repeated for completeness
       (
         self: super: {
@@ -15,9 +14,7 @@ let
             preferWheel = true;
           };
         }
-      )
-
-    ];
+      );
   };
 
   url = lib.elemAt drv.passthru.python.pkgs.maturin.src.urls 0;


### PR DESCRIPTION
This adds the convenience functions withDefaults and
withoutDefaults which simply wrap the provided argument in a list
either with or without the default poetry overrides.

Tests have also been adapted to make use of `withDefaults` where
appropriate.