### PR TITLE
Add overrides for fancycompleter and pylint

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -96,6 +96,16 @@ self: super:
     }
   );
 
+  fancycompleter = super.fancycompleter.overrideAttrs (
+    old: {
+      postPatch = ''
+        substituteInPlace setup.py \
+          --replace 'setup_requires="setupmeta"' 'setup_requires=[]' \
+          --replace 'versioning="devcommit"' 'version="${old.version}"'
+      '';
+    }
+  );
+
   grandalf = super.grandalf.overrideAttrs (
     old: {
       postPatch = ''
@@ -378,6 +388,14 @@ self: super:
     old: {
       nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkgconfig ];
       buildInputs = old.buildInputs ++ [ pkgs.glib pkgs.gobject-introspection ];
+    }
+  );
+
+  pylint = super.pylint.overrideAttrs (
+    old: {
+      postPatch = ''
+        substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"],' 'setup_requires=[],'
+      '';
     }
   );
 


### PR DESCRIPTION
Needed these to work. The `versioning` override for fancycompleter took a while to figure out.

I'm not entirely sure how to test these, but I can say that these overrides work in the project I'm working on.

This PR is sponsored by [Niteo](https://niteo.co/) :sparkles: 