### PR TITLE
Fix pylint override for more recent versions

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -395,6 +395,7 @@ self: super:
     old: {
       postPatch = ''
         substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"],' 'setup_requires=[],'
+        substituteInPlace setup.py --replace "setup_requires=['pytest-runner']," 'setup_requires=[],'
       '';
     }
   );


### PR DESCRIPTION
The `setup.py` in a more recent version of `pylint` changed. This adds another substitution so that both cases are covered.

Note that `substituteInPlace` doesn't fail if no match is found, it just prints a warning.