### PR TITLE
Use canonical pytest-runner name

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -8,7 +8,7 @@ self: super:
 {
   astroid = super.astroid.overrideAttrs (
     old: rec {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pytestrunner ];
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
       doCheck = false;
     }
   );
@@ -89,7 +89,7 @@ self: super:
 
   faker = super.faker.overrideAttrs (
     old: {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pytestrunner ];
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
       doCheck = false;
     }
   );
@@ -106,7 +106,7 @@ self: super:
 
   grandalf = super.grandalf.overrideAttrs (
     old: {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pytestrunner ];
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
       doCheck = false;
     }
   );
@@ -237,7 +237,7 @@ self: super:
 
   mccabe = super.mccabe.overrideAttrs (
     old: {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pytestrunner ];
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
       doCheck = false;
     }
   );
@@ -389,7 +389,7 @@ self: super:
 
   pylint = super.pylint.overrideAttrs (
     old: {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pytestrunner ];
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
       doCheck = false;
     }
   );
@@ -508,6 +508,8 @@ self: super:
       '';
     }
   );
+
+  pytest-runner = super.pytest-runner or super.pytestrunner;
 
   python-prctl = super.python-prctl.overrideAttrs (
     old: {

--- a/overrides.nix
+++ b/overrides.nix
@@ -509,6 +509,12 @@ self: super:
     }
   );
 
+  pytest = super.pytest.overridePythonAttrs (
+    old: {
+      doCheck = false;
+    }
+  );
+
   pytest-runner = super.pytest-runner or super.pytestrunner;
 
   python-prctl = super.python-prctl.overrideAttrs (


### PR DESCRIPTION
If specified in `poetry.lock` we'll use the version from there otherwise we'll fall back to the nixpkgs version.

Also we don't want to introduce a runtime dependency on `pytest-runner` so don't propagate it.