### PR TITLE
Add override for configparser

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -46,6 +46,14 @@ self: super:
     }
   );
 
+  configparser = super.configparser.overridePythonAttrs (
+    old: {
+      buildInputs = old.buildInputs ++ [
+        self.toml
+      ];
+    }
+  );
+
   cryptography = super.cryptography.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ [ pkgs.openssl ];


### PR DESCRIPTION
The `configparser` package uses `setuptools[toml]` and thus needs `toml` to work.