### PR TITLE
Add override for kiwisolver, which has cppy in setup_depends

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -158,6 +158,12 @@ self: super:
     }
   );
 
+  kiwisolver = super.kiwisolver.overridePythonAttrs (
+    old: {
+      buildInputs = old.buildInputs ++ [ self.cppy ];
+    }
+  );
+
   lap = super.lap.overridePythonAttrs (
     old: {
       propagatedBuildInputs = old.propagatedBuildInputs ++ [


### PR DESCRIPTION
This one is interesting, because `cppy` isn't in the `nixpkgs` set of python packages, so this override will only work if `cppy` is also in the poetry env that is being constructed.