### PR TITLE
Avoid calling builtins.head on potentially-empty list of matching wheels

### DIFF
--- a/pep425.nix
+++ b/pep425.nix
@@ -87,8 +87,8 @@ let
         let
           osxMatches = [ "10_12" "10_11" "10_10" "10_9" "any" ];
           linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "any" ];
-          chooseLinux = x: lib.singleton (builtins.head (findBestMatches linuxMatches x));
-          chooseOSX = x: lib.singleton (builtins.head (findBestMatches osxMatches x));
+          chooseLinux = x: lib.take 1 (findBestMatches linuxMatches x);
+          chooseOSX = x: lib.take 1 (findBestMatches osxMatches x);
         in
           if isLinux
           then chooseLinux files


### PR DESCRIPTION
When no matching wheels are found, builtins.head causes this to fail with a very low-level error. Better to return an empty list and trigger the assertion in the code which calls this.

(I tried using `addErrorContext`, but it didn't seem to make the resulting error clearer.)

I also found that I can't run this test on MacOS, since the only `preferWheel` package in the overrides set (and hence the one used by the `prefer-wheel` test) does not have any MacOS wheels. Not sure how to find a legitimate example that the test could use instead, but I guess even an artificial one could work, ie. use a local override that would not normally be necessary, but which would set `preferWheel` and allow for success on all Nix platforms.