### PR TITLE
Add simple github actions checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+    - '**.md'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        nixpkgs_version: ["19.09", "master"]
+        # os: [ubuntu-latest, macos-latest]
+
+    env:
+      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ matrix.nixpgs_version }}.tar.gz"
+    steps:
+    - uses: cachix/install-nix-action@v8
+    - uses: actions/checkout@v1
+    - name: Run tests
+      run: nix-shell -p git --run "nix-build --no-out-link --show-trace tests"
+    - name: Check format
+      run: ./check-fmt


### PR DESCRIPTION
It looked to me like there was no CI for pull requests, so I thought I'd share what a simple Actions config would look like. I personally like having the pull requests marked up automatically with build/check results.

At 30 minutes of runtime, it's pretty slow, I guess due to lack of local caching on the ephemeral build machines - probably the existing gitlab CI runs on a long-lived host - but it could still be useful, and cachix integration would be very easy. It would also be quite easy to enable builds on MacOS using this method: see the commented-out line.