### PR TITLE
Fixed output derivation for wheels fetching

### DIFF
--- a/fetch-wheel.sh
+++ b/fetch-wheel.sh
@@ -1,0 +1,9 @@
+  source $stdenv/setup
+  echo "trying prediction first $predictedURL"
+curl -L -k $predictedURL --output $out 
+  if ! [ $? -ne 0 ]; then
+          echo "prediction failed, asking PyPI's API"
+          URL_FROM_API=$(curl -L -k "https://pypi.org/pypi/$pname/json" | jq -r ".releases.\"$version\"[] | select(.filename == \"$file\") | .url")
+          echo "trying $URL_FROM_API"
+          curl -k $URL_FROM_API --output $out
+  fi

--- a/lib.nix
+++ b/lib.nix
@@ -104,27 +104,26 @@ let
   #   kind: Language implementation and version tag
   fetchWheelFromPypi = lib.makeOverridable
     (
-      { pname, file, hash, kind }:
+      { pname, file, hash, kind, curlOpts ? "" }:
       let
         version = builtins.elemAt (builtins.split "-" file) 2;
       in
       (pkgs.stdenvNoCC.mkDerivation {
         name = file;
-        buildInputs = with pkgs; [ curl jq ];
+        nativeBuildInputs = [
+          pkgs.curl
+          pkgs.jq
+        ];
         isWheel = true;
         system = "builtin";
 
         preferLocalBuild = true;
-        impureEnvVars = [
-          "http_proxy"
-          "https_proxy"
-          "ftp_proxy"
-          "all_proxy"
-          "no_proxy"
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+          "NIX_CURL_FLAGS"
         ];
 
         predictedURL = predictURLFromPypi { inherit pname file hash kind; };
-        inherit pname file version;
+        inherit pname file version curlOpts;
 
         builder = ./fetch-wheel.sh;
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -145,14 +145,15 @@ self: super:
 
   h5py = super.h5py.overridePythonAttrs
     (
-      old: rec {
+      old:
+      if old.format != "wheel" then rec {
         nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkgconfig ];
         buildInputs = old.buildInputs ++ [ pkgs.hdf5 self.pkgconfig self.cython ];
         configure_flags = "--hdf5=${pkgs.hdf5}";
         postConfigure = ''
           ${self.python.executable} setup.py configure ${configure_flags}
         '';
-      }
+      } else old
     );
 
   horovod = super.horovod.overridePythonAttrs
@@ -700,7 +701,8 @@ self: super:
 
   scipy = super.scipy.overridePythonAttrs
     (
-      old: {
+      old:
+      if old.format != "wheel" then {
         nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.gfortran ];
         propagatedBuildInputs = old.propagatedBuildInputs ++ [ self.pybind11 ];
         setupPyBuildFlags = [ "--fcompiler='gnu95'" ];
@@ -713,7 +715,7 @@ self: super:
         preBuild = ''
           ln -s ${self.numpy.cfg} site.cfg
         '';
-      }
+      } else old
     );
 
   scikit-learn = super.scikit-learn.overridePythonAttrs
@@ -805,7 +807,8 @@ self: super:
     }
   ).wheel.overridePythonAttrs
     (
-      _: {
+      old:
+      if old.format == "other" then old else {
         inherit (super.wheel) pname name version src;
       }
     );

--- a/tests/prefer-wheel/default.nix
+++ b/tests/prefer-wheel/default.nix
@@ -15,6 +15,6 @@ let
         }
       );
   };
-  url = lib.elemAt drv.passthru.python.pkgs.maturin.src.urls 0;
+  isWheelAttr = drv.passthru.python.pkgs.maturin.src.isWheel or false;
 in
-  assert lib.hasSuffix "whl" url; drv
+  assert isWheelAttr; drv

--- a/tests/prefer-wheels/default.nix
+++ b/tests/prefer-wheels/default.nix
@@ -1,11 +1,9 @@
 { lib, poetry2nix, python3, runCommand }:
 let
-  app = poetry2nix.mkPoetryApplication {
+  py = poetry2nix.mkPoetryPackages {
     projectDir = ./.;
     preferWheels = true;
   };
-  url = lib.elemAt app.passthru.python.pkgs.tensorflow.src.urls 0;
+  isWheelAttr = py.python.pkgs.tensorflow.src.isWheel or false;
 in
-  assert lib.hasSuffix "whl" url; runCommand "prefer-wheels" { } ''
-    touch $out
-  ''
+  assert isWheelAttr; (py.python.withPackages (_: py.poetryPackages)).override (args: { ignoreCollisions = true; })

--- a/tests/prefer-wheels/poetry.lock
+++ b/tests/prefer-wheels/poetry.lock
@@ -362,7 +362,7 @@ description = "TensorFlow Estimator."
 name = "tensorflow-estimator"
 optional = false
 python-versions = "*"
-version = "2.2.0rc0"
+version = "2.1.0rc0"
 
 [[package]]
 category = "main"
@@ -418,7 +418,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "f1c052ba8df831358ef7630291473df2e0310dc128e9e4e204d746a86cae6b99"
+content-hash = "82b72e0ca256c371b2b647204ea22345c297fb6121831320dbc7a85254bdf478"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -676,7 +676,7 @@ tensorflow = [
     {file = "tensorflow-2.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7bad8ea686a1f33d9dac13eb578c4597346789d4f826980c8bbcfbd08e7dc921"},
 ]
 tensorflow-estimator = [
-    {file = "tensorflow_estimator-2.2.0rc0-py2.py3-none-any.whl", hash = "sha256:c24aba63b33de5db089e66585399e1abefad75038c4aacca8d8d1328ab3e8282"},
+    {file = "tensorflow_estimator-2.1.0rc0-py2.py3-none-any.whl", hash = "sha256:7d835eeb7eaff4d3c3d640be9d9296e9a9213b6172cb4a95317817d180e682c7"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/tests/prefer-wheels/pyproject.toml
+++ b/tests/prefer-wheels/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.6"
 tensorflow = "^2.1.0"
+tensorflow-estimator = "2.1.0rc0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Due to the way PyPI routes its wheels (security reasons apparently), it's impossible to guess the URL, without calling the PyPI API.

For posterity, why `/${kind}/` cannot work is due to this: https://gist.github.com/di/93019b51582899c294cfd76ee2d0a4a3 (list of all python versions in warehouse).

The way this PR attempts to solve it is to call the API and just replace `fetchurl` which is anyway also a fixed-output derivation.