### PR TITLE
Introduce `dependencyEnv` passthru to `mkPoetryApplication`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -229,9 +229,15 @@ let
 
             passthru = {
               python = py;
-              dependencyEnv = py.buildEnv.override {
-                extraLibs = getDeps "dependencies" ++ [ app ];
-              };
+              dependencyEnv =
+                (lib.makeOverridable
+                  ({ app, ... }@attrs:
+                    let
+                      args = builtins.removeAttrs attrs [ "app" ] // {
+                        extraLibs = [ app ];
+                      };
+                    in
+                    py.buildEnv.override args)) { inherit app; };
             };
 
             meta = meta // {

--- a/default.nix
+++ b/default.nix
@@ -150,7 +150,13 @@ let
     in
     py.python.withPackages (_: py.poetryPackages);
 
-  /* Creates a Python application from pyproject.toml and poetry.lock */
+  /* Creates a Python application from pyproject.toml and poetry.lock
+
+     The result also contains a .dependencyEnv attribute which is a python
+     environment of all dependencies and this apps modules. This is useful if
+     you rely on dependencies to invoke your modules for deployment: e.g. this
+     allows `gunicorn my-module:app`.
+  */
   mkPoetryApplication =
     { projectDir ? null
     , src ? poetryLib.cleanPythonSources { src = projectDir; }
@@ -202,34 +208,42 @@ let
         inherit pyProject;
         pythonPackages = py.pkgs;
       };
+      app = py.pkgs.buildPythonPackage
+        (
+          passedAttrs // {
+            pname = moduleName pyProject.tool.poetry.name;
+            version = pyProject.tool.poetry.version;
+
+            inherit src;
+
+            format = "pyproject";
+            # Like buildPythonApplication, but without the toPythonModule part
+            # Meaning this ends up looking like an application but it also
+            # provides python modules
+            namePrefix = "";
+
+            buildInputs = mkInput "buildInputs" buildSystemPkgs;
+            propagatedBuildInputs = mkInput "propagatedBuildInputs" (getDeps "dependencies") ++ ([ py.pkgs.setuptools ]);
+            nativeBuildInputs = mkInput "nativeBuildInputs" [ pkgs.yj py.pkgs.removePathDependenciesHook ];
+            checkInputs = mkInput "checkInputs" (getDeps "dev-dependencies");
+
+            passthru = {
+              python = py;
+              dependencyEnv = py.buildEnv.override {
+                extraLibs = getDeps "dependencies" ++ [ app ];
+              };
+            };
+
+            meta = meta // {
+              inherit (pyProject.tool.poetry) description homepage;
+              inherit (py.meta) platforms;
+              license = getLicenseBySpdxId (pyProject.tool.poetry.license or "unknown");
+            };
+
+          }
+        );
     in
-    py.pkgs.buildPythonApplication
-      (
-        passedAttrs // {
-          pname = moduleName pyProject.tool.poetry.name;
-          version = pyProject.tool.poetry.version;
-
-          inherit src;
-
-          format = "pyproject";
-
-          buildInputs = mkInput "buildInputs" buildSystemPkgs;
-          propagatedBuildInputs = mkInput "propagatedBuildInputs" (getDeps "dependencies") ++ ([ py.pkgs.setuptools ]);
-          nativeBuildInputs = mkInput "nativeBuildInputs" [ pkgs.yj py.pkgs.removePathDependenciesHook ];
-          checkInputs = mkInput "checkInputs" (getDeps "dev-dependencies");
-
-          passthru = {
-            python = py;
-          };
-
-          meta = meta // {
-            inherit (pyProject.tool.poetry) description homepage;
-            inherit (py.meta) platforms;
-            license = getLicenseBySpdxId (pyProject.tool.poetry.license or "unknown");
-          };
-
-        }
-      );
+    app;
 
   /* Poetry2nix CLI used to supplement SHA-256 hashes for git dependencies  */
   cli = import ./cli.nix { inherit pkgs lib version; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -35,6 +35,7 @@ builtins.removeAttrs
   source-filter = callTest ./source-filter { };
   canonical-module-names = callTest ./canonical-module-names { };
   wandb = callTest ./wandb { };
+  dependency-environment = callTest ./dependency-environment { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/dependency-environment/default.nix
+++ b/tests/dependency-environment/default.nix
@@ -6,9 +6,20 @@ let
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
   };
+
+  # Test support for overriding the app passed to the environment
+  overridden = (
+    app.overrideAttrs
+      (old: {
+        name = "${old.pname}-overridden-${old.version}";
+      })
+  );
+  depEnv = app.dependencyEnv.override {
+    app = overridden;
+  };
 in
 runCommand "app-env-test" { } ''
-  ${app.dependencyEnv}/bin/gunicorn --bind=unix:socket trivial:app &
+  ${depEnv}/bin/gunicorn --bind=unix:socket trivial:app &
   sleep 1
   ${curl}/bin/curl --unix-socket socket localhost
   touch $out

--- a/tests/dependency-environment/default.nix
+++ b/tests/dependency-environment/default.nix
@@ -1,0 +1,15 @@
+{ curl, lib, poetry2nix, python3, runCommand }:
+let
+  app = poetry2nix.mkPoetryApplication {
+    python = python3;
+    src = lib.cleanSource ./.;
+    pyproject = ./pyproject.toml;
+    poetrylock = ./poetry.lock;
+  };
+in
+runCommand "app-env-test" { } ''
+  ${app.dependencyEnv}/bin/gunicorn --bind=unix:socket trivial:app &
+  sleep 1
+  ${curl}/bin/curl --unix-socket socket localhost
+  touch $out
+''

--- a/tests/dependency-environment/poetry.lock
+++ b/tests/dependency-environment/poetry.lock
@@ -1,0 +1,22 @@
+[[package]]
+category = "main"
+description = "WSGI HTTP Server for UNIX"
+name = "gunicorn"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "19.10.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.9.7)"]
+gevent = ["gevent (>=0.13)"]
+tornado = ["tornado (>=0.2)"]
+
+[metadata]
+content-hash = "0114cd5ff6f51e66caf2a287d7cd723e38549ec1c57b4999a2585ac6c86b9b06"
+python-versions = "*"
+
+[metadata.files]
+gunicorn = [
+    {file = "gunicorn-19.10.0-py2.py3-none-any.whl", hash = "sha256:c3930fe8de6778ab5ea716cab432ae6335fa9f03b3f2c3e02529214c476f4bcb"},
+    {file = "gunicorn-19.10.0.tar.gz", hash = "sha256:f9de24e358b841567063629cd0a656b26792a41e23a24d0dcb40224fc3940081"},
+]

--- a/tests/dependency-environment/pyproject.toml
+++ b/tests/dependency-environment/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "trivial"
+version = "0.1.0"
+description = "poetry2nix test"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+gunicorn = "*"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tests/dependency-environment/trivial.py
+++ b/tests/dependency-environment/trivial.py
@@ -1,0 +1,10 @@
+def app(environ, start_response):
+    """Simplest possible application object"""
+    data = b'Hello, World!\n'
+    status = '200 OK'
+    response_headers = [
+        ('Content-type', 'text/plain'),
+        ('Content-Length', str(len(data)))
+    ]
+    start_response(status, response_headers)
+    return iter([data])


### PR DESCRIPTION
A combination of `mkPoetryApplication` and `mkPoetryEnv`: An environment with a python interpreter, all dependencies and the application built from pyproject.toml as well. In addition, all binaries know about the python modules of the application. This is useful if your application doesn't have a binary on its own, but relies on dependencies binaries to call its modules.

A test case might be a good idea, but I can say that this works very well with the project I've been testing this with locally.

Ping @adisbladis @energizah

Edit: This PR is newly sponsored by [Niteo](https://niteo.co/)