### PR TITLE
Add override for isort to cover missing dependency on setuptools

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -171,6 +171,13 @@ self: super:
       }
     );
 
+  isort = super.isort.overridePythonAttrs
+    (
+      old: {
+        propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.setuptools ];
+      }
+    );
+
   jupyter = super.jupyter.overridePythonAttrs
     (
       old: rec {


### PR DESCRIPTION
Without this, the wrapped isort binary cannot import setuptools.

Upstream, this will eventually be fixed when the code containing this line gets released:

https://github.com/timothycrosley/isort/blob/3e09facb2311f5b5b8bff8da90f4992e57f4bc9e/isort/main.py#L19