### PR TITLE
Introduce `editablePackageSources` to `mkPoetryEnv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ $ result/bin/gunicorn web:app
 Note: If you need to perform overrides on the application, use `app.dependencyEnv.override { app = app.override { ... }; }`. See [./tests/dependency-environment/default.nix](./tests/dependency-environment/default.nix) for a full example.
 
 ### mkPoetryEnv
-Creates an environment that provides a Python interpreter along with all dependencies declared by the designated poetry project and lock files. `mkPoetryEnv` takes an attribute set with the following attributes (attributes without default are mandatory):
+Creates an environment that provides a Python interpreter along with all dependencies declared by the designated poetry project and lock files. Also allows package sources of an application to be installed in editable mode for fast development. `mkPoetryEnv` takes an attribute set with the following attributes (attributes without default are mandatory):
 
 - **projectDir**: path to the root of the project.
 - **pyproject**: path to `pyproject.toml` (_default_: `projectDir + "/pyproject.toml"`).
 - **poetrylock**: `poetry.lock` file path (_default_: `projectDir + "/poetry.lock"`).
 - **overrides**: Python overrides to apply (_default_: `[defaultPoetryOverrides]`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
 
 #### Example
 ```nix
@@ -78,6 +79,17 @@ poetry2nix.mkPoetryEnv {
 ```
 
 See [./tests/env/default.nix](./tests/env/default.nix) for a working example.
+
+```nix
+poetry2nix.mkPoetryEnv {
+    projectDir = ./.;
+    editablePackageSources = {
+        my-app = ./src;
+    };
+}
+```
+
+See [./tests/editable/default.nix](./tests/editable/default.nix) for a working example of an editable package.
 
 ### mkPoetryPackages
 Creates an attribute set of the shape `{ python, poetryPackages, pyProject, poetryLock }`. Where `python` is the interpreter specified, `poetryPackages` is a list of all generated python packages, `pyProject` is the parsed `pyproject.toml` and `poetryLock` is the parsed `poetry.lock` file. `mkPoetryPackages` takes an attribute set with the following attributes (attributes without default are mandatory):

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -36,6 +36,7 @@ builtins.removeAttrs
   canonical-module-names = callTest ./canonical-module-names { };
   wandb = callTest ./wandb { };
   dependency-environment = callTest ./dependency-environment { };
+  editable = callTest ./editable { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/editable/default.nix
+++ b/tests/editable/default.nix
@@ -1,0 +1,24 @@
+{ lib, poetry2nix, python3, runCommand }:
+let
+  env = poetry2nix.mkPoetryEnv {
+    python = python3;
+    pyproject = ./pyproject.toml;
+    poetrylock = ./poetry.lock;
+
+    editablePackageSources = {
+      # Usually this would be trivial = ./src
+      # But we use this here to be able to test it
+      # in a derivation build
+      trivial = "/build/src";
+    };
+  };
+in
+runCommand "env-test" { } ''
+  cp -r --no-preserve=mode ${./src} src
+  echo 'print("Changed")' > src/trivial/__main__.py
+  if [[ $(${env}/bin/python -m trivial) != "Changed" ]]; then
+    echo "Package wasn't editable!"
+    exit 1
+  fi
+  touch $out
+'' // { inherit env; }

--- a/tests/editable/poetry.lock
+++ b/tests/editable/poetry.lock
@@ -1,0 +1,7 @@
+package = []
+
+[metadata]
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+python-versions = "*"
+
+[metadata.files]

--- a/tests/editable/pyproject.toml
+++ b/tests/editable/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "trivial"
+version = "0.1.0"
+description = "poetry2nix test"
+authors = ["Your Name <you@example.com>"]
+packages = [
+  { include = "trivial", from = "src" },
+]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tests/editable/src/trivial/__main__.py
+++ b/tests/editable/src/trivial/__main__.py
@@ -1,0 +1,1 @@
+print("Original")


### PR DESCRIPTION
This introduces a new parameter to `mkPoetryEnv` which can be used to specify sources for additional python packages that should be available in the resulting environment, loading directly from the mutable source directory. This allows you to call binaries that need to load python modules (like `python -m` or `gunicorn`) for development.

This `editablePackageSources` parameter *could* be read from the [packages](https://python-poetry.org/docs/pyproject/#packages) entry in `pyproject.toml` (or inferred if it doesn't exist), and that's what `poetry install` does, but this would be rather complex to implement correctly, so passing it manually seems to make more sense to me.

The implementation of this works the same way as `poetry install` works: `.pth` files (somewhat documented [here](https://docs.python.org/3.8/library/site.html)) are created in the environments site-packages directory, which reference the mutable directory and lets python know to find the modules there.

This PR is sponsored by [Niteo](https://niteo.co/)