### PR TITLE
Editable eggs

### DIFF
--- a/editable.nix
+++ b/editable.nix
@@ -1,0 +1,54 @@
+{ pkgs
+, lib
+, poetryLib
+, pyProject
+, python
+, editablePackageSources
+}:
+let
+  name = poetryLib.moduleName pyProject.tool.poetry.name;
+
+  # Just enough standard PKG-INFO fields for an editable installation
+  pkgInfoFields = {
+    Metadata-Version = "2.1";
+    Name = name;
+    # While the pyproject.toml could contain arbitrary version strings, for
+    # simplicity we just use the same one for PKG-INFO, even though that
+    # should follow follow PEP 440: https://www.python.org/dev/peps/pep-0345/#version
+    # This is how poetry transforms it: https://github.com/python-poetry/poetry/blob/6cd3645d889f47c10425961661b8193b23f0ed79/poetry/version/version.py
+    Version = pyProject.tool.poetry.version;
+    Summary = pyProject.tool.poetry.description;
+  };
+
+  pkgInfoFile = builtins.toFile "${name}-PKG-INFO"
+    (lib.concatStringsSep "\n" (lib.mapAttrsToList (key: value: "${key}: ${value}") pkgInfoFields));
+
+  entryPointsFile = builtins.toFile "${name}-entry_points.txt"
+    (lib.generators.toINI { } pyProject.tool.poetry.plugins);
+
+  # A python package that contains simple .egg-info and .pth files for an editable installation
+  editablePackage = python.pkgs.toPythonModule (pkgs.runCommandNoCC "${name}-editable"
+    { } ''
+    mkdir -p "$out/${python.sitePackages}"
+    cd "$out/${python.sitePackages}"
+
+    # See https://docs.python.org/3.8/library/site.html for info on such .pth files
+    # These add another site package path for each line
+    touch poetry2nix-editable.pth
+    ${lib.concatMapStringsSep "\n" (src: ''
+      echo "${toString src}" >> poetry2nix-editable.pth
+    '')
+      (lib.attrValues editablePackageSources)}
+
+    # Create a very simple egg so pkg_resources can find this package
+    # See https://setuptools.readthedocs.io/en/latest/formats.html for more info on the egg format
+    mkdir "${name}.egg-info"
+    cd "${name}.egg-info"
+    ln -s ${pkgInfoFile} PKG-INFO
+    ${lib.optionalString (pyProject.tool.poetry ? plugins) ''
+      ln -s ${entryPointsFile} entry_points.txt
+    ''}
+  ''
+  );
+in
+editablePackage

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,6 +37,7 @@ builtins.removeAttrs
   wandb = callTest ./wandb { };
   dependency-environment = callTest ./dependency-environment { };
   editable = callTest ./editable { };
+  editable-egg = callTest ./editable-egg { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/editable-egg/default.nix
+++ b/tests/editable-egg/default.nix
@@ -1,0 +1,42 @@
+{ lib, poetry2nix, python3, runCommand, curl }:
+let
+  env = poetry2nix.mkPoetryEnv {
+    python = python3;
+    pyproject = ./pyproject.toml;
+    poetrylock = ./poetry.lock;
+
+    editablePackageSources = {
+      # Usually this would be trivial = ./src
+      # But we use this here to be able to test it
+      # in a derivation build
+      trivial = "/build/src";
+    };
+  };
+in
+runCommand "env-test"
+{ } ''
+  cp -r --no-preserve=mode ${./src} src
+
+  run() {
+    ${env}/bin/gunicorn --bind=unix:socket --paste ${./paste.ini} &
+    sleep 1
+    result=$(${curl}/bin/curl --unix-socket socket localhost)
+    echo "Got: $result" >&2
+    kill $!
+    echo "$result"
+  }
+
+  if [[ "$(run)" != "Original" ]]; then
+    echo "Package didn't return Original string"
+    exit 1
+  fi
+
+  sed -i 's/Original/Changed/' src/trivial/__init__.py
+
+  if [[ "$(run)" == "Original" ]]; then
+    echo "Package wasn't editable, still returning the Original string even after the source was changed"
+    exit 1
+  fi
+
+  touch $out
+''

--- a/tests/editable-egg/paste.ini
+++ b/tests/editable-egg/paste.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = egg:trivial
+
+

--- a/tests/editable-egg/poetry.lock
+++ b/tests/editable-egg/poetry.lock
@@ -1,0 +1,42 @@
+[[package]]
+category = "main"
+description = "WSGI HTTP Server for UNIX"
+name = "gunicorn"
+optional = false
+python-versions = ">=3.4"
+version = "20.0.4"
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.9.7)"]
+gevent = ["gevent (>=0.13)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
+category = "main"
+description = "Load, configure, and compose WSGI applications and servers"
+name = "pastedeploy"
+optional = false
+python-versions = "*"
+version = "2.1.0"
+
+[package.extras]
+docs = ["Sphinx (>=1.7.5)", "pylons-sphinx-themes"]
+paste = ["paste"]
+
+[metadata]
+content-hash = "c92b82bfb17f2a071c3c5bf512e46f2c6c38a85b7f92a618033a4d8c85a3fced"
+python-versions = "^3.7"
+
+[metadata.files]
+gunicorn = [
+    {file = "gunicorn-20.0.4-py2.py3-none-any.whl", hash = "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"},
+    {file = "gunicorn-20.0.4.tar.gz", hash = "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626"},
+]
+pastedeploy = [
+    {file = "PasteDeploy-2.1.0-py2.py3-none-any.whl", hash = "sha256:bc6578735a32c77435a3e0769426983d3df6dc53a7229290c495ec10aefb81a5"},
+    {file = "PasteDeploy-2.1.0.tar.gz", hash = "sha256:e7559878b6e92023041484be9bcb6d767cf4492fc3de7257a5dae76a7cc11a9b"},
+]

--- a/tests/editable-egg/pyproject.toml
+++ b/tests/editable-egg/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "trivial"
+version = "0.1.0"
+description = "poetry2nix test"
+authors = ["Your Name <you@example.com>"]
+packages = [
+  { include = "trivial", from = "src" },
+]
+
+[tool.poetry.plugins."paste.app_factory"]
+main = "trivial:app_factory"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+gunicorn = "^20.0.4"
+pastedeploy = "^2.1.0"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tests/editable-egg/src/trivial/__init__.py
+++ b/tests/editable-egg/src/trivial/__init__.py
@@ -1,0 +1,13 @@
+def app(environ, start_response):
+    """Simplest possible application object"""
+    data = b'Original\n'
+    status = '200 OK'
+    response_headers = [
+        ('Content-type', 'text/plain'),
+        ('Content-Length', str(len(data)))
+    ]
+    start_response(status, response_headers)
+    return iter([data])
+
+def app_factory(global_config, **local_conf):
+    return app


### PR DESCRIPTION
In https://github.com/nix-community/poetry2nix/pull/101, `editablePackageSources` was introduced, but later [I discovered](https://github.com/nix-community/poetry2nix/pull/101#issuecomment-629870767) that this doesn't work for [`pkg_resources.require()`](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#basic-workingset-methods), which needs an installed egg to find the package.

With this change, this is fixed by making `mkPoetryEnv` install a very basic static egg.

In the first commit, a failing test is added, showcasing what didn't work previously, whereas the second commit makes it work.

This PR is sponsored by [Niteo](https://niteo.co/)