### PR TITLE
Fix nested git dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -80,7 +80,7 @@ let
                       source = pkgMeta.source or null;
                       files = lockFiles.${name};
                       pythonPackages = self;
-                      sourceSpec = pyProject.tool.poetry.dependencies.${name} or pyProject.tool.poetry.dev-dependencies.${name};
+                      sourceSpec = pyProject.tool.poetry.dependencies.${name} or pyProject.tool.poetry.dev-dependencies.${name} or { };
                     }
                   );
                 }


### PR DESCRIPTION
When a dependency itself has a git dependency the metadata to infer `ref` is not available in `pyproject.toml` and we have to fall back to `HEAD`.