### PR TITLE
Make pyarrow override compatible with newer nixpkgs

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -454,7 +454,14 @@ self: super:
       old:
       let
         parseMinor = drv: lib.concatStringsSep "." (lib.take 2 (lib.splitVersion drv.version));
-        _arrow-cpp = pkgs.arrow-cpp.override { inherit (self) python; };
+
+        # Starting with nixpkgs revision f149c7030a7, pyarrow takes "python3" as an argument
+        # instead of "python". Below we inspect function arguments to maintain compatibilitiy.
+        _arrow-cpp = pkgs.arrow-cpp.override (
+          builtins.intersectAttrs
+            (lib.functionArgs pkgs.arrow-cpp.override) { python = self.python; python3 = self.python; }
+        );
+
         ARROW_HOME = _arrow-cpp;
         arrowCppVersion = parseMinor pkgs.arrow-cpp;
         pyArrowVersion = parseMinor super.pyarrow;


### PR DESCRIPTION
Since the nixpkgs change https://github.com/NixOS/nixpkgs/commit/f149c7030a7#diff-b7d8c4fa8c1a2ad2832a889247b62e3bL3, `arrow-cpp` package expects an argument named `python3` instead of just `python`. This commit adds a compatibility fix so that the package can also be used with a newer nixpkgs.