### PR TITLE
Fix moduleName not being applied for accessing python pkgs set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        nixpkgs_version: ["19.09", "master"]
+        nixpkgs_version: ["20.03", "master"]
         # os: [ubuntu-latest, macos-latest]
     env:
       NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ matrix.nixpgs_version }}.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
     steps:
     - uses: cachix/install-nix-action@v8
     - uses: actions/checkout@v1
-    - uses: cachix/cachix-action@v5
+    - uses: cachix/cachix-action@v6
       with:
         name: poetry2nix
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-        file: tests/default.nix
+    - run: nix-build --show-trace tests/default.nix

--- a/default.nix
+++ b/default.nix
@@ -206,7 +206,7 @@ let
           (
             dep:
             let
-              pkg = py.pkgs."${dep}";
+              pkg = py.pkgs."${moduleName dep}";
               constraints = deps.${dep}.python or "";
               isCompat = compat constraints;
             in

--- a/tests/eggs/default.nix
+++ b/tests/eggs/default.nix
@@ -1,7 +1,7 @@
-{ lib, poetry2nix, python3, runCommandNoCC }:
+{ lib, poetry2nix, python37, runCommandNoCC }:
 let
   drv = poetry2nix.mkPoetryApplication {
-    python = python3;
+    python = python37;
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     src = lib.cleanSource ./.;

--- a/tests/manylinux/default.nix
+++ b/tests/manylinux/default.nix
@@ -1,7 +1,7 @@
-{ runCommand, lib, poetry2nix, python3 }:
+{ runCommand, lib, poetry2nix, python37 }:
 let
   pkg = poetry2nix.mkPoetryApplication {
-    python = python3;
+    python = python37;
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     src = lib.cleanSource ./.;

--- a/tests/prefer-wheel/default.nix
+++ b/tests/prefer-wheel/default.nix
@@ -1,7 +1,7 @@
-{ lib, poetry2nix, python3 }:
+{ lib, poetry2nix, python37 }:
 let
   drv = poetry2nix.mkPoetryApplication {
-    python = python3;
+    python = python37;
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     src = lib.cleanSource ./.;

--- a/tests/prefer-wheels/default.nix
+++ b/tests/prefer-wheels/default.nix
@@ -1,6 +1,7 @@
-{ lib, poetry2nix, python3, runCommand }:
+{ lib, poetry2nix, python37, runCommand }:
 let
   py = poetry2nix.mkPoetryPackages {
+    python = python37;
     projectDir = ./.;
     preferWheels = true;
   };


### PR DESCRIPTION
Fixes #126, was an oversight in https://github.com/nix-community/poetry2nix/pull/87

Note that moduleName is being applied to define the python pkgs overlay in https://github.com/nix-community/poetry2nix/blob/e7c69a288c10e4d97816fdabda5ae3f38e21914e/default.nix#L113, so it's also necessary when accessing the attributes

Ping @adisbladis @domenkozar @suryasr007