### PR TITLE
Always add Poetry as a build input unless bootstrapping

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ let
     , python ? pkgs.python3
     , pwd ? projectDir
     , preferWheels ? false
+    , __isBootstrap ? false  # Hack: Always add Poetry as a build input unless bootstrapping
     }@attrs:
     let
       poetryPkg = poetry.override { inherit python; };
@@ -80,6 +81,7 @@ let
                   value = self.mkPoetryDep (
                     pkgMeta // {
                       inherit pwd preferWheels;
+                      inherit __isBootstrap;
                       source = pkgMeta.source or null;
                       files = lockFiles.${name};
                       pythonPackages = self;
@@ -181,11 +183,12 @@ let
     , python ? pkgs.python3
     , pwd ? projectDir
     , preferWheels ? false
+    , __isBootstrap ? false  # Hack: Always add Poetry as a build input unless bootstrapping
     , ...
     }@attrs:
     let
       poetryPython = mkPoetryPackages {
-        inherit pyproject poetrylock overrides python pwd preferWheels;
+        inherit pyproject poetrylock overrides python pwd preferWheels __isBootstrap;
       };
       py = poetryPython.python;
 

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -17,6 +17,7 @@
 , sourceSpec
 , supportedExtensions ? lib.importJSON ./extensions.json
 , preferWheels ? false
+, __isBootstrap ? false  # Hack: Always add Poetry as a build input unless bootstrapping
 , ...
 }:
 
@@ -106,6 +107,7 @@ pythonPackages.callPackage
         baseBuildInputs
         ++ lib.optional (!isSource) (getManyLinuxDeps fileInfo.name).pkg
         ++ lib.optional isLocal buildSystemPkgs
+        ++ lib.optional (!__isBootstrap) [ pythonPackages.poetry ]
       );
 
       propagatedBuildInputs =

--- a/pkgs/poetry/default.nix
+++ b/pkgs/poetry/default.nix
@@ -7,6 +7,9 @@ poetry2nix.mkPoetryApplication {
 
   projectDir = ./.;
 
+  # Don't include poetry in inputs
+  __isBootstrap = true;
+
   src = fetchFromGitHub (lib.importJSON ./src.json);
 
   # "Vendor" dependencies (for build-system support)


### PR DESCRIPTION
Currently Poetry does not have a notion of build-time
dependencies (setup-requires) in it's lock file.

When installing a dependency built with Poetry this has to be added
via an override which is really bad UX.

This change always adds Poetry as an interim solution until we have
resolved this in upstream Poetry.