### PR TITLE
Use poetry.masonry.api build-backend by default

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -154,12 +154,10 @@ let
     , pyProject
     }:
     let
-      buildSystem = lib.attrByPath [ "build-system" "build-backend" ] "" pyProject;
+      buildSystem = lib.attrByPath [ "build-system" "build-backend" ] "poetry.masonry.api" pyProject;
       drvAttr = moduleName (builtins.elemAt (builtins.split "\\.|:" buildSystem) 0);
     in
-    if buildSystem == "" then [ ] else (
-      [ pythonPackages.${drvAttr} or (throw "unsupported build system ${buildSystem}") ]
-    );
+    [ pythonPackages.${drvAttr} or (throw "unsupported build system ${buildSystem}") ];
 
   # Find gitignore files recursively in parent directory stopping with .git
   findGitIgnores = path:


### PR DESCRIPTION
Because `poetry build` works too without having any `build-backend` specified.

Not doing this can cause problems for the final application, a symptom of which seems to be that the package metadata isn't detected, leading to UNKNOWN eggs in the python environment.

An alternative would be to throw an error or a warning, pushing people to adding a `build-backend` section, but since peotry doesn't do that, poetry2nix shouldn't do it too imo.