### PR TITLE
Add override for ffmpeg-python

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -753,6 +753,12 @@ self: super:
     }
   );
 
+  ffmpeg-python = super.ffmpeg-python.overridePythonAttrs (
+    old: {
+      buildInputs = old.buildInputs ++ [ self.pytest-runner ];
+    }
+  );
+
   python-prctl = super.python-prctl.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ [


### PR DESCRIPTION
Adds `pytest-runner` as a build input, handling #139 