### PR TITLE
Add override for vispy

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -907,6 +907,16 @@ self: super:
     }
   );
 
+  vispy = super.vispy.overrideAttrs (
+    old: {
+      inherit (pkgs.python3.pkgs.vispy) patches;
+      nativeBuildInputs = old.nativeBuildInputs ++ [
+        self.cython
+        self.setuptools-scm-git-archive
+      ];
+    }
+  );
+
   uvloop = super.uvloop.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Closes #99 

Note there is a bug with building numpy > 1.19.0, and this depends no setuptools-scm with toml. See the following pyproject.toml

```toml
[tool.poetry]
name = "vispy_test"
version = "0.1.0"
description = ""
authors = ["Michael Lingelbach <m.j.lbach@gmail.com>"]

[tool.poetry.dependencies]
python = "^3.6"
numpy = "1.19.0"
vispy = "0.6.4"

[tool.poetry.dev-dependencies]
setuptools-scm = { version = "^3.4", extras = ["toml"] }


[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"
```

And shell.nix

```nix
with import <nixpkgs> {};
with import ../poetry2nix/overlay.nix pkgs pkgs;
let
  pythonEnv = poetry2nix.mkPoetryEnv {
    projectDir = ./.;
    preferWheels = false;
  };
in
mkShell {
  name = "vispy_environment";

  nativeBuildInputs = [
    pythonEnv
  ];
}
```