### PR TITLE
overrides: Matplotlib 3.3.0 now downloads/builds it's own freetype by default

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -333,6 +333,13 @@ self: super:
         pkgs.pkgconfig
       ];
 
+      postPatch = ''
+        cat > setup.cfg <<EOF
+        [libs]
+        system_freetype = True
+        EOF
+      '';
+
       propagatedBuildInputs = old.propagatedBuildInputs ++ [
         pkgs.libpng
         pkgs.freetype


### PR DESCRIPTION
Override to use system (nix) freetype.