### PR TITLE
Add openssl for psycopg2-binary on Darwin

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -459,6 +459,8 @@ self: super:
 
   psycopg2-binary = super.psycopg2-binary.overridePythonAttrs (
     old: {
+      buildInputs = old.buildInputs
+        ++ lib.optional stdenv.isDarwin pkgs.openssl;
       nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.postgresql ];
     }
   );


### PR DESCRIPTION
In previous PR I forgot about psycopg2-binary.

This is part of https://github.com/nix-community/poetry2nix/issues/146