### PR TITLE
override: for mongomock

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -431,6 +431,10 @@ self: super:
       buildInputs = old.buildInputs ++ [ self.setuptools-scm-git-archive ];
     });
 
+  mongomock = super.mongomock.overridePythonAttrs (oa: {
+    buildInputs = oa.buildInputs ++ [ self.pbr ];
+  });
+
   netcdf4 = super.netcdf4.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ [


### PR DESCRIPTION
 requires pbr as can be seen https://github.com/mongomock/mongomock/blob/develop/setup.py

Fixes https://github.com/nix-community/poetry2nix/issues/164