### PR TITLE
overrides.nix: handle zipp being null gracefully

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1133,25 +1133,25 @@ self: super:
     in
     if isWheel then wheelPackage else sourcePackage;
 
-  zipp =
-    (
-      if lib.versionAtLeast super.zipp.version "2.0.0" then (
-        super.zipp.overridePythonAttrs (
-          old: {
-            prePatch = ''
-              substituteInPlace setup.py --replace \
-              'setuptools.setup()' \
-              'setuptools.setup(version="${super.zipp.version}")'
-            '';
-          }
-        )
-      ) else super.zipp
-    ).overridePythonAttrs (
-      old: {
-        propagatedBuildInputs = old.propagatedBuildInputs ++ [
-          self.toml
-        ];
-      }
-    );
+  zipp = if super.zipp == null then null else
+  (
+    if lib.versionAtLeast super.zipp.version "2.0.0" then (
+      super.zipp.overridePythonAttrs (
+        old: {
+          prePatch = ''
+            substituteInPlace setup.py --replace \
+            'setuptools.setup()' \
+            'setuptools.setup(version="${super.zipp.version}")'
+          '';
+        }
+      )
+    ) else super.zipp
+  ).overridePythonAttrs (
+    old: {
+      propagatedBuildInputs = old.propagatedBuildInputs ++ [
+        self.toml
+      ];
+    }
+  );
 
 }


### PR DESCRIPTION
If your poetry.lock file contains a marker making a dependency optional
on a specific python version, super.zipp is null, so getting its version
will fail. There's other code handling these being null (followups on
https://github.com/nix-community/poetry2nix/issues/50), so just make
this code handle it more gracefully, too.

Co-authored-by: Florian Klink <flokli@flokli.de>