### PR TITLE
fix "invalid Git revision 'master'"

### DIFF
--- a/bin/poetry2nix
+++ b/bin/poetry2nix
@@ -23,6 +23,11 @@ parser_lock.add_argument(
 
 
 def fetch_git(pkg):
+    try:
+        reference = pkg["source"]["resolved_reference"]
+    except KeyError:
+        reference = pkg["source"]["reference"]
+
     return (
         pkg["name"],
         subprocess.run(
@@ -32,7 +37,7 @@ def fetch_git(pkg):
                 "--url",
                 pkg["source"]["url"],
                 "--rev",
-                pkg["source"]["resolved_reference"],
+                reference,
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/bin/poetry2nix
+++ b/bin/poetry2nix
@@ -32,7 +32,7 @@ def fetch_git(pkg):
                 "--url",
                 pkg["source"]["url"],
                 "--rev",
-                pkg["source"]["reference"],
+                pkg["source"]["resolved_reference"],
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -157,7 +157,7 @@ pythonPackages.callPackage
           (
             builtins.fetchGit {
               inherit (source) url;
-              rev = source.reference;
+              rev = source.resolved_reference;
               ref = sourceSpec.branch or sourceSpec.rev or sourceSpec.tag or "HEAD";
             }
           ) else if isLocal then (poetryLib.cleanPythonSources { src = localDepPath; }) else

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -157,7 +157,7 @@ pythonPackages.callPackage
           (
             builtins.fetchGit {
               inherit (source) url;
-              rev = source.resolved_reference;
+              rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or sourceSpec.rev or sourceSpec.tag or "HEAD";
             }
           ) else if isLocal then (poetryLib.cleanPythonSources { src = localDepPath; }) else


### PR DESCRIPTION
When running nix-shell after added a git dependency, it complains invalid Git revision 'master'.
I think it should always prefer `resolved_reference` to `reference`