### PR TITLE
don't match macos version of rusty-rlp package

### DIFF
--- a/pep425.nix
+++ b/pep425.nix
@@ -87,7 +87,7 @@ let
       filtered = builtins.filter filterWheel filesWithoutSources;
       choose = files:
         let
-          osxMatches = [ "10_12" "10_11" "10_10" "10_9" "any" ];
+          osxMatches = [ "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
           linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "any" ];
           chooseLinux = x: lib.take 1 (findBestMatches linuxMatches x);
           chooseOSX = x: lib.take 1 (findBestMatches osxMatches x);


### PR DESCRIPTION
- add 10_8 and 10_7 to macos version list

how to reproduce:
```
$ poetry new testpoetry
$ cd testpoetry
$ poetry add rusty-rlp
$ cat > shell.nix << EOF
with import <nixpkgs> { };
poetry2nix.mkPoetryEnv {
  projectDir = ./.;
}
EOF
$ nix-shell
error: list index 0 is out of bounds, at /nix/store/.../nixpkgs/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix:71:27
(use '--show-trace' to show detailed location information)
```