### PR TITLE
Fix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,32 @@ in pkgs.poetry2nix.mkPoetryApplication {
 }
 ```
 
+## Using the flake
+
+For the experimental flakes functionality we provide poetry2nix as a flake providing an overlay
+to use with [nixpkgs](https://nixos.org/nixpkgs/manual).
+
+#### Example
+
+```nix
+{
+    description = "Your flake using poetry2nix";
+
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+    inputs.utils.url = "github:numtide/flake-utils";
+    inputs.poetry2nix-src.url = "github:nix-community/poetry2nix";
+
+    outputs = {nixpkgs, utils, poetry2nix-src, self}: utils.lib.eachDefaultSystem (system: let
+
+      pkgs = import nixpkgs { inherit system; overlays = [ poetry2nix-src.overlay ]; };
+
+    in
+      {
+         # use pkgs.poetry2nix here.
+      });
+  }
+```
+
 ## Contributing
 
 Contributions to this project are welcome in the form of GitHub PRs. Please consider the following before creating PRs:

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,8 @@
 {
   description = "Poetry2nix flake";
 
-  outputs = { self, nixpkgs }:
-    let
-      # TODO: There must be a better way to provide arch-agnostic flakes..
-      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-      # Memoize nixpkgs for different platforms for efficiency.
-      nixpkgsFor = forAllSystems (
-        system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ self.overlay ];
-        }
-      );
-    in
+  outputs = { self }:
     {
-
       overlay = import ./overlay.nix;
-
-      # TODO: I feel like `packages` is the wrong place for the poetry2nix attr
-      packages = forAllSystems (
-        system: {
-          inherit (nixpkgsFor.${system}) poetry poetry2nix;
-        }
-      );
-
     };
 }


### PR DESCRIPTION
At the moment

```
nix flake show --no-write-lock-file github:nix-community/poetry2nix
```

fails with

```
* Added 'nixpkgs': 'github:NixOS/nixpkgs/e286f0cf3bcffd5c0f006bb1831563d63b281fb2'
github:nix-community/poetry2nix/1894b501cf4431fb218c4939a9acdbf397ac1803
├───overlay: Nixpkgs overlay
└───packages
    ├───aarch64-linux
    │   ├───poetry: package 'python3.8-poetry-1.1.4'
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
expected a derivation
```

So it seams stuff in `packages` output need to be a derivation.

To turn poetry2nix into a proper flake, just remove the packages. Its not needed anyways and just forces people to download nixpkgs  checkout another time.

Of course flakes is experimental and such sort of breakage is to be expected, I think it would be good to fix it up anyway.