### PR TITLE
fix(flake): overlay args are standardized

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,7 +1,7 @@
-self: super: {
+final: prev: {
 
-  poetry2nix = import ./default.nix { pkgs = self; poetry = self.poetry; };
+  poetry2nix = import ./default.nix { pkgs = final; poetry = final.poetry; };
 
-  poetry = super.callPackage ./pkgs/poetry { python = self.python3; };
+  poetry = prev.callPackage ./pkgs/poetry { python = final.python3; };
 
 }


### PR DESCRIPTION
when trying to use poetry2nix overlay in my flake, I get:
error: --- Error --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
overlay does not take an argument named 'final'
------------------------------------------------------------------------------------------ show-trace ------------------------------------------------------------------------------------------
trace: while checking the overlay 'overlays.poetry2nix'