### PR TITLE
Overrides for packaging and pytest

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -972,6 +972,10 @@ self: super:
 
   pytest = super.pytest.overridePythonAttrs (
     old: {
+      # Fixes https://github.com/pytest-dev/pytest/issues/7891
+      postPatch = old.postPatch or "" + ''
+        sed -i '/\[metadata\]/aversion = ${old.version}' setup.cfg
+      '';
       doCheck = false;
     }
   );

--- a/overrides.nix
+++ b/overrides.nix
@@ -1303,6 +1303,15 @@ self: super:
     }
   );
 
+  packaging = super.packaging.overridePythonAttrs (
+    old: {
+      buildInputs = old.buildInputs ++
+        # From 20.5 until 20.7, packaging used flit for packaging (heh)
+        # See https://github.com/pypa/packaging/pull/352 and https://github.com/pypa/packaging/pull/367
+        lib.optional (lib.versionAtLeast old.version "20.5" && lib.versionOlder old.version "20.8") [ self.flit-core ];
+    }
+  );
+
   supervisor = super.supervisor.overridePythonAttrs (
     old: {
       propagatedBuildInputs = old.propagatedBuildInputs ++ [


### PR DESCRIPTION
Fixes `packaging` build newly failing with
```
ModuleNotFoundError: No module named 'flit_core'
```

And also fixes pytest having version 0.0.0 (fixes #188), see also https://github.com/pytest-dev/pytest/issues/7891, not sure if there's a better way to fix this