### PR TITLE
mysqlclient: Add missing native library dependency

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -561,6 +561,12 @@ self: super:
     }
   );
 
+  mysqlclient = super.mysqlclient.overridePythonAttrs (
+    old: {
+      buildInputs = old.buildInputs ++ [ pkgs.libmysqlclient ];
+    }
+  );
+
   netcdf4 = super.netcdf4.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ [


### PR DESCRIPTION
I am using this override in my project-specific nix file, but I think it would make sense to include it in poetry2nix. The code is copy-pasted so it should work(tm).... I am not sure how to best test this PR?