### PR TITLE
Add overrides for datadog libraries

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -132,6 +132,18 @@ self: super:
     }
   );
 
+  datadog-lambda = super.datadog-lambda.overridePythonAttrs (old: {
+    postPatch = ''
+      substituteInPlace setup.py --replace "setuptools==" "setuptools>="
+    '';
+    buildInputs = old.buildInputs ++ [ self.setuptools ];
+  });
+
+  ddtrace = super.ddtrace.overridePythonAttrs (old: {
+    buildInputs = old.buildInputs ++
+      (pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.IOKit ]) ++ [ self.cython ];
+  });
+
   dictdiffer = super.dictdiffer.overridePythonAttrs (
     old: {
       buildInputs = old.buildInputs ++ [ self.pytest-runner ];


### PR DESCRIPTION
Hi, I'd like to add overrides for two Datadog-related libs. The problem I faced was related to `datadog-lambda` library that depends on `ddtrace`. 

1. `Cython` was missing in the dependencies of `ddtrace`.
2. While testing the build on different machine (MacOS) the `darwin.IOKit` package was required.
3. The `datadog-lambda` itself didn't build with current version of setuptools. 

## Simplified poetry project:
```toml
[tool.poetry]
name = "hello"
version = "0.1.0"
description = ""
authors = []

[tool.poetry.dependencies]
python = "^3.8"
datadog-lambda = "^2.26.0"

[tool.poetry.dev-dependencies]
pytest = "^5.2"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```
## Cython error:
```bash
nix-shell
(...)

WARNING: The directory '/homeless-shelter/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Processing /tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/ddtrace-0.44.0
    ERROR: Command errored out with exit status 1:
     command: /nix/store/i9lzacdfrwlj1ayw551c016s0fq71p7j-python3-3.8.6/bin/python3.8 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/pip-req-build-k2l21syq/setup.py'"'"'; __file__='"'"'/tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/pip-req-build-k2l21syq/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/pip-pip-egg-info-acoc32j4
         cwd: /tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/pip-req-build-k2l21syq/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/nix-build-python3.8-ddtrace-0.44.0.drv-0/pip-req-build-k2l21syq/setup.py", line 10, in <module>
        from Cython.Build import cythonize  # noqa: I100
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
builder for '/nix/store/s0ca6jp01sk7m7f5fbbb0sxpcx4psh10-python3.8-ddtrace-0.44.0.drv' failed with exit code 1
cannot build derivation '/nix/store/1a7fqw0a8q44xi79lfgykqv1q25iwchx-python3.8-datadog-lambda-2.26.0.drv': 1 dependencies couldn't be built
error: build of '/nix/store/1a7fqw0a8q44xi79lfgykqv1q25iwchx-python3.8-datadog-lambda-2.26.0.drv' failed
```

## Setuptools error:
```bash
nix-shell

(...)

Executing pipInstallPhase
/tmp/nix-build-python3.8-datadog-lambda-2.26.0.drv-0/datadog_lambda-2.26.0/dist /tmp/nix-build-python3.8-datadog-lambda-2.26.0.drv-0/datadog_lambda-2.26.0
Processing ./datadog_lambda-2.26.0-py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement setuptools==42.0.2 (from datadog-lambda==2.26.0) (from versions: none)
ERROR: No matching distribution found for setuptools==42.0.2 (from datadog-lambda==2.26.0)
builder for '/nix/store/xw2jn901hxf2h478cbii826jayzjj0kl-python3.8-datadog-lambda-2.26.0.drv' failed with exit code 1
cannot build derivation '/nix/store/rk3avcvvaga0a75px0sq4ia7a43pjr22-python3-3.8.5-env.drv': 1 dependencies couldn't be built
error: build of '/nix/store/rk3avcvvaga0a75px0sq4ia7a43pjr22-python3-3.8.5-env.drv' failed
```

I formatted the code using nixfmt, so the change should be clean. It would be great if someone could review this!