### PR TITLE
overrides: fix wheel inputs to support different versions of python

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1273,11 +1273,9 @@ self: super:
         pkgs.python3.pkgs.override {
           python = self.python;
         }
-      ).wheel.overridePythonAttrs (
-        old: {
-          inherit (super.wheel) pname name version src;
-        }
-      );
+      ).wheel.override {
+        inherit (self) buildPythonPackage bootstrapped-pip setuptools;
+      };
     in
     if isWheel then wheelPackage else sourcePackage;
 

--- a/tests/manylinux/default.nix
+++ b/tests/manylinux/default.nix
@@ -1,7 +1,7 @@
 { runCommand, lib, poetry2nix, python37 }:
 let
   pkg = poetry2nix.mkPoetryApplication {
-    # python = python37;
+    python = python37;
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     src = lib.cleanSource ./.;


### PR DESCRIPTION
This PR is a possible solution for #232.

Closes #232

Problem:

The issue demonstrates that building a poetry environment or application
fails when using a different python version.

I trace this down to the fact that

```nix
pkgs.python3.pkgs.override { python = self.python; }
```

is not sufficient to override tools that get used to build/bootstrap packages
such as `buildPythonPackage`, `bootstrapped-pip`, and `setuptools`, all three
of which are used to build the `wheel` package.

This led to every version of wheel being built for whatever version `python3`
corresponds to for whatever version of `nixpkgs` is being used.
