### PR TITLE
Expose functions for editable & scripts packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The _poetry2nix_ public API consists of the following attributes:
 - [mkPoetryApplication](#mkPoetryApplication): Creates a Python application.
 - [mkPoetryEnv](#mkPoetryEnv): Creates a Python environment with an interpreter and all packages from `poetry.lock`.
 - [mkPoetryPackages](#mkPoetryPackages): Creates an attribute set providing access to the generated packages and other artifacts.
+- [mkPoetryScriptsPackage](#mkPoetryScriptsPackage): Creates a package containing the scripts from `tool.poetry.scripts` of the `pyproject.toml`.
+- [mkPoetryEditablePackage](#mkPoetryEditablePackage): Creates a package containing editable sources. Changes in the specified paths will be reflected in an interactive nix-shell session without the need to restart it.
 - [defaultPoetryOverrides](#defaultPoetryOverrides): A set of bundled overrides fixing problems with Python packages.
 - [overrides.withDefaults](#overrideswithDefaults): A convenience function for specifying overrides on top of the defaults.
 - [overrides.withoutDefaults](#overrideswithoutDefaults): A convenience function for specifying overrides without defaults.
@@ -80,6 +82,7 @@ poetry2nix.mkPoetryEnv {
 
 See [./tests/env/default.nix](./tests/env/default.nix) for a working example.
 
+#### Example with editable packages
 ```nix
 poetry2nix.mkPoetryEnv {
     projectDir = ./.;
@@ -131,6 +134,60 @@ Creates an attribute set of the shape `{ python, poetryPackages, pyProject, poet
 - **poetrylock**: `poetry.lock` file path (_default_: `projectDir + "/poetry.lock"`).
 - **overrides**: Python overrides to apply (_default_: `[defaultPoetryOverrides]`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
+
+#### Example
+```nix
+poetry2nix.mkPoetryPackages {
+    projectDir = ./.;
+    python = python35;
+}
+```
+
+### mkPoetryScriptsPackage
+Creates a package containing the scripts from `tool.poetry.scripts` of the `pyproject.toml`:
+
+- **projectDir**: path to the root of the project.
+- **pyproject**: path to `pyproject.toml` (_default_: `projectDir + "/pyproject.toml"`).
+- **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+
+#### Example
+```nix
+poetry2nix.mkPoetryScriptsPackage {
+    projectDir = ./.;
+    python = python35;
+}
+```
+
+### mkPoetryEditablePackage
+Creates a package containing editable sources. Changes in the specified paths will be reflected in an interactive nix-shell session without the need to restart it:
+
+- **projectDir**: path to the root of the project.
+- **pyproject**: path to `pyproject.toml` (_default_: `projectDir + "/pyproject.toml"`).
+- **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
+
+#### Example
+```nix
+poetry2nix.mkPoetryEditablePackage {
+    projectDir = ./.;
+    python = python35;
+    editablePackageSources = {
+        my-app = ./src;
+    };
+}
+```
+
+
+### mkPoetryPackages
+Creates an attribute set of the shape `{ python, poetryPackages, pyProject, poetryLock }`. Where `python` is the interpreter specified, `poetryPackages` is a list of all generated python packages, `pyProject` is the parsed `pyproject.toml` and `poetryLock` is the parsed `poetry.lock` file. `mkPoetryPackages` takes an attribute set with the following attributes (attributes without default are mandatory):
+
+- **projectDir**: path to the root of the project.
+- **pyproject**: path to `pyproject.toml` (_default_: `projectDir + "/pyproject.toml"`).
+- **poetrylock**: `poetry.lock` file path (_default_: `projectDir + "/poetry.lock"`).
+- **overrides**: Python overrides to apply (_default_: `[defaultPoetryOverrides]`).
+- **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
 
 #### Example
 ```nix

--- a/default.nix
+++ b/default.nix
@@ -73,6 +73,39 @@ lib.makeScope pkgs.newScope (self: {
   # Poetry2nix version
   version = "1.14.0";
 
+  /* Returns a package of editable sources whose changes will be available without needing to restart the
+     nix-shell.
+     In editablePackageSources you can pass a mapping from package name to source directory to have
+     those packages available in the resulting environment, whose source changes are immediately available.
+     
+  */
+  mkPoetryEditablePackage =
+    { projectDir ? null
+    , pyproject ? projectDir + "/pyproject.toml"
+    , python ? pkgs.python3
+    , pyProject ? readTOML pyproject
+      # Example: { my-app = ./src; }
+    , editablePackageSources
+    }:
+      assert editablePackageSources != { };
+      import ./editable.nix {
+        inherit pyProject python pkgs lib poetryLib editablePackageSources;
+      };
+
+  /* Returns a package containing scripts defined in tool.poetry.scripts.
+  */
+  mkPoetryScriptsPackage =
+    { projectDir ? null
+    , pyproject ? projectDir + "/pyproject.toml"
+    , python ? pkgs.python3
+    , pyProject ? readTOML pyproject
+    , scripts ? pyProject.tool.poetry.scripts
+    }:
+      assert scripts != { };
+      import ./shell-scripts.nix {
+        inherit lib python scripts;
+      };
+
   /*
      Returns an attrset { python, poetryPackages, pyProject, poetryLock } for the given pyproject/lockfile.
   */
@@ -84,11 +117,25 @@ lib.makeScope pkgs.newScope (self: {
     , python ? pkgs.python3
     , pwd ? projectDir
     , preferWheels ? false
+      # Example: { my-app = ./src; }
+    , editablePackageSources ? { }
     , __isBootstrap ? false  # Hack: Always add Poetry as a build input unless bootstrapping
     }@attrs:
     let
       poetryPkg = poetry.override { inherit python; };
       pyProject = readTOML pyproject;
+
+      scripts = pyProject.tool.poetry.scripts or { };
+      hasScripts = scripts != { };
+      scriptsPackage = self.mkPoetryScriptsPackage {
+        inherit python scripts;
+      };
+
+      hasEditable = editablePackageSources != { };
+      editablePackage = self.mkPoetryEditablePackage {
+        inherit pyProject python editablePackageSources;
+      };
+
       poetryLock = readTOML poetrylock;
       lockFiles =
         let
@@ -180,10 +227,13 @@ lib.makeScope pkgs.newScope (self: {
 
       inputAttrs = mkInputAttrs { inherit py pyProject; attrs = { }; includeBuildSystem = false; };
 
+      storePackages = builtins.foldl' (acc: v: acc ++ v) [ ] (lib.attrValues inputAttrs);
     in
     {
       python = py;
-      poetryPackages = builtins.foldl' (acc: v: acc ++ v) [ ] (lib.attrValues inputAttrs);
+      poetryPackages = storePackages
+        ++ lib.optional hasScripts scriptsPackage
+        ++ lib.optional hasEditable editablePackage;
       poetryLock = poetryLock;
       inherit pyProject;
     };
@@ -203,38 +253,17 @@ lib.makeScope pkgs.newScope (self: {
     , pwd ? projectDir
     , python ? pkgs.python3
     , preferWheels ? false
-      # Example: { my-app = ./src; }
     , editablePackageSources ? { }
     }:
     let
-      py = self.mkPoetryPackages (
-        {
-          inherit pyproject poetrylock overrides python pwd preferWheels;
-        }
-      );
-
-      inherit (py) pyProject;
-
-      # Add executables from tool.poetry.scripts
-      scripts = pyProject.tool.poetry.scripts or { };
-      hasScripts = scripts != { };
-      scriptsPackage = import ./shell-scripts.nix {
-        inherit scripts lib;
-        inherit (py) python;
+      poetryPython = self.mkPoetryPackages {
+        inherit pyproject poetrylock overrides python pwd preferWheels editablePackageSources;
       };
 
-      hasEditable = editablePackageSources != { };
-      editablePackage = import ./editable.nix {
-        inherit pkgs lib poetryLib editablePackageSources;
-        inherit (py) pyProject python;
-      };
+      inherit (poetryPython) poetryPackages;
 
     in
-    py.python.withPackages (
-      _: py.poetryPackages
-        ++ lib.optional hasEditable editablePackage
-        ++ lib.optional hasScripts scriptsPackage
-    );
+    poetryPython.python.withPackages (_: poetryPackages);
 
   /* Creates a Python application from pyproject.toml and poetry.lock
 


### PR DESCRIPTION
> The editablePackage and scriptsPackage elements of the mkPoetryEnv
> function are wholly separable and really ought to be moved into the
> functionality of the mkPoetryPackages function. By doing so both will
> automatically be available in the mkPoetryApplication's dependencyEnv as
> well.
> 
> I thought the functionality that encapsulates these might further see
> potential use even outside the context of mkPoetryPackages, so I made
> them top-level functions and documented them in the README.


I wasn't sure how to add tests for these changes. Please let me know if you have any suggestions in that vein.