### PR TITLE
gitignore: ignore direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 result*
 artifacts
 poetry2nix-flamegraph.svg
+.direnv


### PR DESCRIPTION
This PR adds `.direnv` to the repository `.gitignore` file.
