### PR TITLE
Ensure ref passed to builtins.fetchGit points to refs/tags/sourceSpec…

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -161,7 +161,7 @@ pythonPackages.callPackage
             builtins.fetchGit {
               inherit (source) url;
               rev = source.resolved_reference or source.reference;
-              ref = sourceSpec.branch or sourceSpec.rev or sourceSpec.tag or "HEAD";
+              ref = sourceSpec.branch or sourceSpec.rev or (if sourceSpec?tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             }
           )
         else if isUrl then


### PR DESCRIPTION
On master, tests currently fail with tags:

```
❯ nix-build tests/default.nix  --show-trace
fatal: couldn't find remote ref refs/heads/4321bbfda9aa190acdad05eb901d3b59439f0ec9
error: --- Error ---------------------------------------------------------------------------------------------------------------------------------------------------------- nix-build
program 'git' failed with exit code 128
------------------------------------------------------------------------------------ show-trace -------------------------------------------------------------------------------------
trace: while evaluating the attribute 'src.name'
```

The remote ref *should* be 
```
 remote ref refs/tags/4321bbfda9aa190acdad05eb901d3b59439f0ec9
```