### PR TITLE
Fix stdenv.platform accesses for latest nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { }
 , lib ? pkgs.lib
 , poetry ? null
-, poetryLib ? import ./lib.nix { inherit lib pkgs; }
+, poetryLib ? import ./lib.nix { inherit lib pkgs; stdenv = pkgs.stdenv; }
 }:
 let
   inherit (poetryLib) isCompatible readTOML moduleName;

--- a/lib.nix
+++ b/lib.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs }:
+{ lib, pkgs, stdenv }:
 let
   inherit (import ./semver.nix { inherit lib ireplace; }) satisfiesSemver;
   inherit (builtins) genList length;
@@ -194,6 +194,23 @@ let
         inherit src;
       };
     };
+
+  # Maps Nixpkgs CPU values to target machines known to be supported for manylinux* wheels.
+  # (a.k.a. `uname -m` output from CentOS 7)
+  #
+  # This is current as of manylinux2014 (PEP-0599), and is a superset of manylinux2010 / manylinux1.
+  # s390x is not supported in Nixpkgs, so we don't map it.
+  manyLinuxTargetMachines = {
+    x86_64 = "x86_64";
+    i686 = "i686";
+    aarch64 = "aarch64";
+    armv7l = "armv7l";
+    powerpc64 = "ppc64";
+    powerpc64le = "ppc64le";
+  };
+
+  # Machine tag for our target platform (if available)
+  targetMachine = manyLinuxTargetMachines.${stdenv.targetPlatform.parsed.cpu.name} or null;
 in
 {
   inherit
@@ -207,5 +224,6 @@ in
     cleanPythonSources
     moduleName
     getPythonVersion
+    targetMachine
     ;
 }

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -31,7 +31,7 @@ pythonPackages.callPackage
       inherit (poetryLib) isCompatible getManyLinuxDeps fetchFromPypi moduleName;
 
       inherit (import ./pep425.nix {
-        inherit lib python;
+        inherit lib poetryLib python;
         inherit (pkgs) stdenv;
       }) selectWheel
         ;

--- a/pep425.nix
+++ b/pep425.nix
@@ -1,6 +1,7 @@
-{ lib, stdenv, python, isLinux ? stdenv.isLinux }:
+{ lib, stdenv, poetryLib, python, isLinux ? stdenv.isLinux }:
 let
   inherit (lib.strings) hasSuffix hasInfix splitString removeSuffix;
+  inherit (poetryLib) targetMachine;
 
   # The 'cpxy" as determined by `python.version`
   #
@@ -72,12 +73,16 @@ let
       withPlatform =
         if isLinux
         then
-          (
-            x: x.platform == "manylinux1_${stdenv.platform.kernelArch}"
-              || x.platform == "manylinux2010_${stdenv.platform.kernelArch}"
-              || x.platform == "manylinux2014_${stdenv.platform.kernelArch}"
-              || x.platform == "any"
-          )
+          if targetMachine != null
+          then
+            (
+              x: x.platform == "manylinux1_${targetMachine}"
+                || x.platform == "manylinux2010_${targetMachine}"
+                || x.platform == "manylinux2014_${targetMachine}"
+                || x.platform == "any"
+            )
+          else
+            (x: x.platform == "any")
         else (x: hasInfix "macosx" x.platform || x.platform == "any");
       filterWheel = x:
         let

--- a/pep508.nix
+++ b/pep508.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, poetryLib }: python:
 let
-  inherit (poetryLib) ireplace;
+  inherit (poetryLib) ireplace targetMachine;
 
   # Like builtins.substring but with stop being offset instead of length
   substr = start: stop: s: builtins.substring start (stop - start) s;
@@ -95,7 +95,7 @@ let
           else if stdenv.isDarwin then "darwin"
           else throw "Unsupported platform"
         );
-        platform_machine = stdenv.platform.kernelArch;
+        platform_machine = targetMachine;
         platform_python_implementation =
           let
             impl = python.passthru.implementation;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2,9 +2,10 @@
 let
   poetry = pkgs.callPackage ../pkgs/poetry { python = pkgs.python3; inherit poetry2nix; };
   poetry2nix = import ./.. { inherit pkgs;inherit poetry; };
-  pep425 = pkgs.callPackage ../pep425.nix { };
-  pep425Python37 = pkgs.callPackage ../pep425.nix { python = pkgs.python37; };
-  pep425OSX = pkgs.callPackage ../pep425.nix { isLinux = false; };
+  poetryLib = import ../lib.nix { inherit pkgs; lib = pkgs.lib; stdenv = pkgs.stdenv; };
+  pep425 = pkgs.callPackage ../pep425.nix { inherit poetryLib; };
+  pep425Python37 = pkgs.callPackage ../pep425.nix { inherit poetryLib; python = pkgs.python37; };
+  pep425OSX = pkgs.callPackage ../pep425.nix { inherit poetryLib; isLinux = false; };
   skipTests = builtins.filter (t: builtins.typeOf t != "list") (builtins.split "," (builtins.getEnv "SKIP_TESTS"));
   callTest = test: attrs: pkgs.callPackage test ({ inherit poetry2nix; } // attrs);
 in


### PR DESCRIPTION
This fixes builds being completely broken after:
* https://github.com/NixOS/nixpkgs/pull/110726
* https://github.com/NixOS/nixpkgs/pull/110544

I'm not sure if this should be handled in a backwards compatible way, but if it is, I'd be happy to adjust the patch.