### PR TITLE
Fix mkPoetryPackages: should return deps of deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,11 @@ Contributions to this project are welcome in the form of GitHub PRs. Please cons
 - This project uses [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) for formatting the Nix code. You can use
 `nix-shell --run "nixpkgs-fmt .` to format everything.
 - If you are planning to make any considerable changes, you should first present your plans in a GitHub issue so it can be discussed.
-- If you add new features please consider adding tests.
+- If you add new features please consider adding tests. You can run them locally as follows:
 
+```bash
+nix-build --keep-going --show-trace tests/default.nix
+```
 
 ## License
 _poetry2nix_ is released under the terms of the MIT license.

--- a/default.nix
+++ b/default.nix
@@ -227,8 +227,7 @@ lib.makeScope pkgs.newScope (self: {
 
       inputAttrs = mkInputAttrs { inherit py pyProject; attrs = { }; includeBuildSystem = false; };
 
-      currentPython = pkgs.lib.attrByPath [ python.pname ] python pkgs;
-      requiredPythonModules = currentPython.pkgs.requiredPythonModules;
+      requiredPythonModules = python.pkgs.requiredPythonModules;
       /* Include all the nested dependencies which are required for each package.
          This guarantees that using the "poetryPackages" attribute will return
          complete list of dependencies for the poetry project to be portable.

--- a/default.nix
+++ b/default.nix
@@ -229,7 +229,10 @@ lib.makeScope pkgs.newScope (self: {
 
       currentPython = pkgs.lib.attrByPath [ python.pname ] python pkgs;
       requiredPythonModules = currentPython.pkgs.requiredPythonModules;
-      # TODO: This deserves a comment
+      /* Include all the nested dependencies which are required for each package.
+         This guarantees that using the "poetryPackages" attribute will return
+         complete list of dependencies for the poetry project to be portable.
+      */
       storePackages = requiredPythonModules (builtins.foldl' (acc: v: acc ++ v) [ ] (lib.attrValues inputAttrs));
     in
     {

--- a/default.nix
+++ b/default.nix
@@ -161,7 +161,7 @@ lib.makeScope pkgs.newScope (self: {
       compatible = partitions.right;
       incompatible = partitions.wrong;
 
-      # Create an overriden version of pythonPackages
+      # Create an overridden version of pythonPackages
       #
       # We need to avoid mixing multiple versions of pythonPackages in the same
       # closure as python can only ever have one version of a dependency
@@ -227,7 +227,10 @@ lib.makeScope pkgs.newScope (self: {
 
       inputAttrs = mkInputAttrs { inherit py pyProject; attrs = { }; includeBuildSystem = false; };
 
-      storePackages = builtins.foldl' (acc: v: acc ++ v) [ ] (lib.attrValues inputAttrs);
+      currentPython = pkgs.lib.attrByPath [ python.pname ] python pkgs;
+      requiredPythonModules = currentPython.pkgs.requiredPythonModules;
+      # TODO: This deserves a comment
+      storePackages = requiredPythonModules (builtins.foldl' (acc: v: acc ++ v) [ ] (lib.attrValues inputAttrs));
     in
     {
       python = py;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -49,6 +49,7 @@ builtins.removeAttrs
   editable = callTest ./editable { };
   editable-egg = callTest ./editable-egg { };
   ansible-molecule = callTest ./ansible-molecule { };
+  mk-poetry-packages = callTest ./mk-poetry-packages { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/mk-poetry-packages/default.nix
+++ b/tests/mk-poetry-packages/default.nix
@@ -3,13 +3,23 @@
 
    Note: this test assumes that "certifi" lib is going to be a dep of "requests" in the future.
 */
-{ lib, poetry2nix, python3 }:
+{ lib, poetry2nix, python3, python37 }:
 let
   inherit (builtins) elem map;
-  drv = poetry2nix.mkPoetryPackages {
+  drvPythonCurrent = poetry2nix.mkPoetryPackages {
     projectDir = ./.;
     python = python3;
   };
-  packageNames = map (package: package.pname) drv.poetryPackages;
+
+  # Test backward compatibility
+  drvPython37 = poetry2nix.mkPoetryPackages {
+    projectDir = ./.;
+    python = python37;
+  };
+
+  packageNamesCurrent = map (package: package.pname) drvPythonCurrent.poetryPackages;
+  packageNamesPython37 = map (package: package.pname) drvPython37.poetryPackages;
 in
-assert builtins.elem "certifi" packageNames; drv
+assert builtins.elem "certifi" packageNamesCurrent;
+assert builtins.elem "certifi" packageNamesPython37;
+drvPythonCurrent

--- a/tests/mk-poetry-packages/default.nix
+++ b/tests/mk-poetry-packages/default.nix
@@ -1,3 +1,8 @@
+/* It is assumed that propagated dependencies are included in the poetryPackages.
+   The "certifi" is direct dependency of "requests" library.
+
+   Note: this test assumes that "certifi" lib is going to be a dep of "requests" in the future.
+*/
 { lib, poetry2nix, python3 }:
 let
   inherit (builtins) elem map;

--- a/tests/mk-poetry-packages/default.nix
+++ b/tests/mk-poetry-packages/default.nix
@@ -1,10 +1,10 @@
-{ lib, poetry2nix, python37 }:
-
+{ lib, poetry2nix, python38 }:
 let
   inherit (builtins) elem map;
   drv = poetry2nix.mkPoetryPackages {
     projectDir = ./.;
-    python = python37;
+    python = python38;
   };
   packageNames = map (package: package.pname) drv.poetryPackages;
-in assert builtins.elem "certifi" packageNames; drv
+in
+assert builtins.elem "certifi" packageNames; drv

--- a/tests/mk-poetry-packages/default.nix
+++ b/tests/mk-poetry-packages/default.nix
@@ -1,9 +1,9 @@
-{ lib, poetry2nix, python38 }:
+{ lib, poetry2nix, python3 }:
 let
   inherit (builtins) elem map;
   drv = poetry2nix.mkPoetryPackages {
     projectDir = ./.;
-    python = python38;
+    python = python3;
   };
   packageNames = map (package: package.pname) drv.poetryPackages;
 in

--- a/tests/mk-poetry-packages/default.nix
+++ b/tests/mk-poetry-packages/default.nix
@@ -1,0 +1,10 @@
+{ lib, poetry2nix, python37 }:
+
+let
+  inherit (builtins) elem map;
+  drv = poetry2nix.mkPoetryPackages {
+    projectDir = ./.;
+    python = python37;
+  };
+  packageNames = map (package: package.pname) drv.poetryPackages;
+in assert builtins.elem "certifi" packageNames; drv

--- a/tests/mk-poetry-packages/poetry.lock
+++ b/tests/mk-poetry-packages/poetry.lock
@@ -1,0 +1,81 @@
+[[package]]
+name = "certifi"
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "requests"
+version = "2.25.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "urllib3"
+version = "1.26.3"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "90aad50b58fecb5c614871cf7e4cecc70c09e06d669300e65510f7299ed21d30"
+
+[metadata.files]
+certifi = [
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+requests = [
+    {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
+    {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
+    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
+]

--- a/tests/mk-poetry-packages/poetry.lock
+++ b/tests/mk-poetry-packages/poetry.lock
@@ -55,8 +55,8 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "90aad50b58fecb5c614871cf7e4cecc70c09e06d669300e65510f7299ed21d30"
+python-versions = "^3.8"
+content-hash = "c7b0119ca233bd369221338d4e3bd93bfe7ed46cd9c788ddccc23908d1a25c28"
 
 [metadata.files]
 certifi = [

--- a/tests/mk-poetry-packages/pyproject.toml
+++ b/tests/mk-poetry-packages/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 requests = "^2.25.1"
 
 [tool.poetry.dev-dependencies]

--- a/tests/mk-poetry-packages/pyproject.toml
+++ b/tests/mk-poetry-packages/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "mk-poetry-packages"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "^2.25.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=1.0.0"]
+build-backend = "poetry.masonry.api"

--- a/tests/mk-poetry-packages/pyproject.toml
+++ b/tests/mk-poetry-packages/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "mk-poetry-packages"
 version = "0.1.0"
-description = ""
-authors = ["Your Name <you@example.com>"]
+description = "Tests if mkPoetryPackages API is stable"
+authors = []
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This is a fix for [#247 mkPoetryPackages no longer propagates dependencies
](https://github.com/nix-community/poetry2nix/issues/247)

@adisbladis Please take a look and check if this is stable solution!

Important facts:
- I'm doing some string operations on python.pythonVersion to produce right attribute (should look like this: `python37`, `python38`, etc.) and I have no idea if there is better option for that.
- Added tests for current and older version of Python.
- Added documentation how to run tests locally (Tests finish with "Hello, World!" and gunicorn server listening, is this expected?).