### PR TITLE
Provide necessary overrides to build `sentence-transformers`

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1560,6 +1560,20 @@ self: super:
     }
   );
 
+  sentencepiece = super.sentencepiece.overridePythonAttrs (
+    old: {
+      dontUseCmakeConfigure = true;
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+        pkgs.pkg-config
+        pkgs.cmake
+        pkgs.gperftools
+      ];
+      buildInputs = (old.buildInputs or [ ]) ++ [
+        pkgs.sentencepiece
+      ];
+    }
+  );
+
   supervisor = super.supervisor.overridePythonAttrs (
     old: {
       propagatedBuildInputs = old.propagatedBuildInputs ++ [

--- a/overrides.nix
+++ b/overrides.nix
@@ -1574,6 +1574,14 @@ self: super:
     }
   );
 
+  sentence-transformers = super.sentence-transformers.overridePythonAttrs (
+    old: {
+      buildInputs =
+        (old.buildInputs or [ ])
+        ++ [ self.typing-extensions ];
+    }
+  );
+
   supervisor = super.supervisor.overridePythonAttrs (
     old: {
       propagatedBuildInputs = old.propagatedBuildInputs ++ [

--- a/overrides.nix
+++ b/overrides.nix
@@ -1388,6 +1388,14 @@ self: super:
     }
   );
 
+  # The tokenizers build requires a complex rust setup (cf. nixpkgs override)
+  #
+  # Instead of providing a full source build, we use a wheel to keep
+  # the complexity manageable for now.
+  tokenizers = super.tokenizers.override {
+    preferWheel = true;
+  };
+
   torch = lib.makeOverridable
     ({ enableCuda ? false
      , cudatoolkit ? pkgs.cudatoolkit_10_1


### PR DESCRIPTION
More info in the commit msgs.

As you can see, I kinda chickened out for `tokenizers` and used a wheel after seeing the nixpkgs override: https://github.com/NixOS/nixpkgs/blob/f5e8bdd07d1afaabf6b37afc5497b1e498b8046f/pkgs/development/python-modules/tokenizers/default.nix#L50

Is there a way to re-use the nixpkgs source build? If not, I hope the wheel is good enough!