### PR TITLE
Add override for psutil on darwin

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1620,6 +1620,13 @@ self: super:
     }
   );
 
+  psutil = super.psutil.overridePythonAttrs (
+    old: {
+      buildInputs = (old.buildInputs or [ ]) ++
+        lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.IOKit;
+    }
+  );
+
   sentencepiece = super.sentencepiece.overridePythonAttrs (
     old: {
       dontUseCmakeConfigure = true;


### PR DESCRIPTION
Using poetry2nix on macOS, I just found psutil's missing dependency on Apple SDK.
It would be convenient if it is in the default overrides.