### PR TITLE
Add override for python-snappy

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1245,6 +1245,12 @@ self: super:
     }
   );
 
+  python-snappy = super.python-snappy.overridePythonAttrs (
+    old: {
+      buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.snappy ];
+    }
+  );
+
   ffmpeg-python = super.ffmpeg-python.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [ self.pytest-runner ];


### PR DESCRIPTION
python-snappy depends on snappy library.
It would be convenient if it is in the default overrides.