### PR TITLE
overrides: add pytest-runner dependency for aiohttp-swagger3

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -12,6 +12,12 @@ self: super:
     }
   );
 
+  aiohttp-swagger3 = super.aiohttp-swagger3.overridePythonAttrs (
+    old: {
+      nativeBuildInputs = old.nativeBuildInputs ++ [ self.pytest-runner ];
+    }
+  );
+
   ansible = super.ansible.overridePythonAttrs (
     old: {
 


### PR DESCRIPTION
Aiohttp-swagger3 fails to build with this minimal pyproject.toml:
```
[tool.poetry]
name = "poetry2nix"
version = "0.1.0"
description = ""
authors = ["Your Name <you@example.com>"]

[tool.poetry.dependencies]
python = "^3.8"
aiohttp-swagger3 = ">=0.5.3"

[tool.poetry.dev-dependencies]

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```
Seems like pytest-runner dependency is missing, so this PR adds it.