### PR TITLE
importlib-metadata: Don't remove pyproject.toml

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -436,6 +436,9 @@ self: super:
   importlib-metadata = super.importlib-metadata.overridePythonAttrs (
     old: {
       propagatedBuildInputs = old.propagatedBuildInputs ++ lib.optional self.python.isPy2 self.pathlib2;
+
+      # disable the removal of pyproject.toml, required because of setuptools_scm
+      dontPreferSetupPy = true;
     }
   );
 


### PR DESCRIPTION
Without this change a build depending on recent versions of `keyring` results in:

> ERROR: Could not find a version that satisfies the requirement importlib-metadata>=3.6 (from keyring==23.0.1) (from versions: none)
> ERROR: No matching distribution found for importlib-metadata>=3.6 (from keyring==23.0.1)