### PR TITLE
Use compiled version of mypy (mypyc)

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -706,6 +706,12 @@ self: super:
     }
   );
 
+  mypy = super.mypy.overridePythonAttrs (
+    old: {
+      MYPY_USE_MYPYC = pkgs.stdenv.buildPlatform.is64bit;
+    }
+  );
+
   mysqlclient = super.mysqlclient.overridePythonAttrs (
     old: {
       nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.libmysqlclient ];


### PR DESCRIPTION
Use compiled version (this supposed to offer 4x speed improvement over pure python, it's also the version that is provided through wheels).