### PR TITLE
fix regex for darwin-aarch64 compatability

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -37,7 +37,7 @@ pythonPackages.callPackage
         ;
       fileCandidates =
         let
-          supportedRegex = ("^.*?(" + builtins.concatStringsSep "|" supportedExtensions + ")");
+          supportedRegex = ("^.*(" + builtins.concatStringsSep "|" supportedExtensions + ")");
           matchesVersion = fname: builtins.match ("^.*" + builtins.replaceStrings [ "." ] [ "\\." ] version + ".*$") fname != null;
           hasSupportedExtension = fname: builtins.match supportedRegex fname != null;
           isCompatibleEgg = fname: ! lib.strings.hasSuffix ".egg" fname || lib.strings.hasSuffix "py${python.pythonVersion}.egg" fname;


### PR DESCRIPTION
Currently I'm unable to run poetry2nix on aarch64-darwin, same as noted in this ticket https://github.com/NixOS/nix/issues/4758 I'm also getting

```
error: invalid regular expression '^.*?(egg|tar|tar.bz2|tar.gz|tar.lz|tar.lzma|tar.xz|tbz|tgz|tlz|txz|whl|zip)'
```

I believe this is related to differences in stdlib++ versions, altough this is not my area of expertise.
The question mark isn't necessary here, I hope this showcases that

```
nix-repl> builtins.match "?(egg)" "asdf"
error: invalid regular expression '?(egg)'

       at «string»:1:1:

            1| builtins.match "?(egg)" "asdf"
             | ^
            2|

nix-repl> builtins.match "^.*?(egg)" "asdf"
error: invalid regular expression '^.*?(egg)'

       at «string»:1:1:

            1| builtins.match "^.*?(egg)" "asdf"
             | ^
            2|

nix-repl> builtins.match "^.*(egg)" "asdf"
null

nix-repl> builtins.match "^.*(egg)" "asdf.egg"
[ "egg" ]

nix-repl> builtins.match "^.*(egg)" ""
null

nix-repl> builtins.match "^.*(egg)" "egg"
[ "egg" ]

nix-repl> builtins.match "^.*(egg)" ".egg"
[ "egg" ]
```

