### PR TITLE
Define setuptools-scm only if it is not already defined

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -209,12 +209,12 @@ lib.makeScope pkgs.newScope (self: {
                   poetry-core = if __isBootstrap then null else poetryPkg.passthru.python.pkgs.poetry-core;
                   poetry = if __isBootstrap then null else poetryPkg;
 
-                  # The canonical name is setuptools-scm
-                  setuptools-scm = super.setuptools_scm;
-
                   __toPluginAble = toPluginAble self;
 
                   inherit (hooks) pipBuildHook removePathDependenciesHook poetry2nixFixupHook wheelUnpackHook;
+                } // lib.optionalAttrs (! super ? setuptools-scm) {
+                  # The canonical name is setuptools-scm
+                  setuptools-scm = super.setuptools_scm;
                 }
             )
             # Null out any filtered packages, we don't want python.pkgs from nixpkgs


### PR DESCRIPTION
This is because of changes in [nixpkgs](https://github.com/NixOS/nixpkgs/pull/125477), which results in infinite recursion because of the treewide refactor. The refactor changed 
`setuptools_scm` to `setuptools-scm`, however, it also aliased `setuptools_scm`  to `setuptools-scm`. Poetry2nix then aliases `setuptools-scm` to `setuptools_scm` resulting in infinite recursion. 