### PR TITLE
Add overrides for multiple packages

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1865,4 +1865,28 @@ self: super:
     '';
   });
 
+  pygraphviz = super.pygraphviz.overridePythonAttrs (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.pkg-config ];
+    buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.graphviz ];
+  });
+
+  pyjsg = super.pyjsg.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.pbr ];
+  });
+
+  pyshex = super.pyshex.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.pbr ];
+  });
+
+  pyshexc = super.pyshexc.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.pbr ];
+  });
+
+  shexjsg = super.shexjsg.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.pbr ];
+  });
+
+  sparqlslurper = super.sparqlslurper.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.pbr ];
+  });
 }


### PR DESCRIPTION
This pull request fixes multiple packages:

- pygraphviz
- pyjsg
- pyshex
- pyshexc
- shexjsg
- sparqlslurper

Unfortunately, I think there are lot of packages depend on `pbr`. Is there any way to automatically detect the `pbr` requirement and apply the fix to the derivation?