### PR TITLE
pep508: Fix `in`

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -71,7 +71,10 @@ pythonPackages.callPackage
           sourceDist = builtins.filter isSdist fileCandidates;
           eggs = builtins.filter isEgg fileCandidates;
           entries = (if preferWheel then binaryDist ++ sourceDist else sourceDist ++ binaryDist) ++ eggs;
-          lockFileEntry = builtins.head entries;
+          lockFileEntry = (
+            if lib.length entries > 0 then builtins.head entries
+            else throw "Missing suitable source/wheel file entry for ${name}"
+          );
           _isEgg = isEgg lockFileEntry;
         in
         rec {

--- a/pep508.nix
+++ b/pep508.nix
@@ -132,7 +132,8 @@ let
               mVal = ''[a-zA-Z0-9\'"_\. \-]+'';
               mOp = "in|[!=<>]+";
               e = stripStr exprs.value;
-              m = builtins.map stripStr (builtins.match ''^(${mVal}) *(${mOp}) *(${mVal})$'' e);
+              m' = builtins.match ''^(${mVal}) +(${mOp}) *(${mVal})$'' e;
+              m = builtins.map stripStr (if m' != null then m' else builtins.match ''^(${mVal}) +(${mOp}) *(${mVal})$'' e);
               m0 = processVar (builtins.elemAt m 0);
               m2 = processVar (builtins.elemAt m 2);
             in


### PR DESCRIPTION
If a marker contains two or more instances of the substring "in" Nix regex engine in it's infitine wisdom splits only on the last one.
    
By changing a `*` to a `+` we can get the desired behaviour, but we do need to fall back to the previous behaviour in case the more restrictive match is not working.
