### PR TITLE
Enable dataset module in pyarrow

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -969,6 +969,7 @@ self: super:
             ];
 
             PYARROW_BUILD_TYPE = "release";
+            PYARROW_WITH_DATASET = true;
             PYARROW_WITH_PARQUET = true;
             PYARROW_CMAKE_OPTIONS = [
               "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"


### PR DESCRIPTION
I think this is worth enabling as it is used by dask when loading data from parquet files. You get `ModuleNotFoundError: No module named 'pyarrow._dataset'` at runtime if you try without having this enabled.