### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   # Poetry2nix version
-  version = "1.17.1";
+  version = "1.18.0";
 
   inherit (poetryLib) isCompatible readTOML moduleName;
 


### PR DESCRIPTION
Because it would be nice to have a new release in nixpkgs (i mainly interested by a `fetch-from-legacy` fix).

(Once released, I could then submit a PR in nixpkgs.)