### PR TITLE
Expose projectDir/pyproject/poetrylock parameters in the Poetry derivation

### DIFF
--- a/check-fmt
+++ b/check-fmt
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell ./shell.nix -i bash
+#!nix-shell ./check-fmt.nix -i bash
 #
 # Just because the nixpkgs-fmt error message is not super readable. Used by
 # CI.

--- a/check-fmt.nix
+++ b/check-fmt.nix
@@ -1,0 +1,7 @@
+let
+  sources = import ./nix/sources.nix;
+  pkgs = import sources.nixpkgs { };
+in
+pkgs.mkShell {
+  nativeBuildInputs = [ pkgs.nixpkgs-fmt ];
+}

--- a/pkgs/poetry/default.nix
+++ b/pkgs/poetry/default.nix
@@ -1,11 +1,18 @@
-{ lib, poetry2nix, python, fetchFromGitHub }:
+{ lib
+, poetry2nix
+, python
+, fetchFromGitHub
+, projectDir ? ./.
+, pyproject ? projectDir + "/pyproject.toml"
+, poetrylock ? projectDir + "/poetry.lock"
+}:
 
 
 poetry2nix.mkPoetryApplication {
 
   inherit python;
 
-  projectDir = ./.;
+  inherit projectDir pyproject poetrylock;
 
   # Don't include poetry in inputs
   __isBootstrap = true;


### PR DESCRIPTION
This simplifies overriding Poetry with a different version.
    
Related issue: https://github.com/nix-community/poetry2nix/issues/345
