### PR TITLE
Fix using git deps with rev= in pyproject.toml

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -163,11 +163,11 @@ pythonPackages.callPackage
       src =
         if isGit then
           (
-            builtins.fetchGit {
+            builtins.fetchGit ({
               inherit (source) url;
               rev = source.resolved_reference or source.reference;
-              ref = sourceSpec.branch or sourceSpec.rev or (if sourceSpec?tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
-            }
+              ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
+            } // (if sourceSpec ? rev then { allRefs = true; } else { }))
           )
         else if isUrl then
           builtins.fetchTarball


### PR DESCRIPTION
Currently poetry2nix calls builtins.fetchGit with ref=\<rev\>, which Nix
translates to ref=refs/heads/\<rev\> and breaks (git):

```
$ nix-build
+ /usr/bin/git -C /home/bf/.cache/nix/gitv3/1aba8psc37ekc9ph2m5ziidm644mj84yrrj7g6x8amy3g13kyjm4 cat-file -e 4d41bada407267a008473547085f8242bb8663e5
+ /usr/bin/git -C
/home/bf/.cache/nix/gitv3/1aba8psc37ekc9ph2m5ziidm644mj84yrrj7g6x8amy3g13kyjm4 fetch --quiet --force -- ssh://git@server.example/repo.git refs/heads/4d41bada407267a008473547085f8242bb8663e5:refs/heads/4d41bada407267a008473547085f8242bb8663e5
fatal: Couldn't find remote ref refs/heads/4d41bada407267a008473547085f8242bb8663e5
error: program 'git' failed with exit code 128
(use '--show-trace' to show detailed location information)
fatal: the remote end hung up unexpectedly
```

(I wrote a git wrapper that traces the calls to the real git.)

Unfortunately, poetry does not support specifying both branch= and rev=
in pyproject.toml (it ignores branch= if rev= is set), so we have to fix
this in poetry2nix. (At least for now.)

Fix it by using the new builtins.fetchGit 'allRefs' parameter when rev=
is set. This parameter is only available in nixUnstable, but as the
current code is broken anyway, I think that's ok.
