### PR TITLE
feat: Make virtualenv installable

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1971,4 +1971,10 @@ self: super:
   tomli = super.tomli.overridePythonAttrs (old: {
     buildInputs = (old.buildInputs or [ ]) ++ [ self.flit-core ];
   });
+
+  virtualenv = super.virtualenv.overridePythonAttrs (old: {
+    postPatch = ''
+      substituteInPlace setup.cfg --replace 'platformdirs>=2,<3' 'platformdirs'
+    '';
+  });
 }


### PR DESCRIPTION
I do not fully understand why the version specification breaks the
installation, because `poetry install` and `pip install
--requirement=<(poetry export)` both work just fine.

Closes #340.