### PR TITLE
licensecheck override

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -594,6 +594,10 @@ self: super:
     propagatedBuildInputs = [ pkgs.libvirt ];
   });
 
+  licensecheck = super.licensecheck.overridePythonAttrs (old: {
+    dontPreferSetupPy = true;
+  });
+
   llvmlite = super.llvmlite.overridePythonAttrs (
     old:
     let


### PR DESCRIPTION
The `setup.py` generated by poetry appears to be broken for some reason.