### PR TITLE
Enable '+' in package versions, and some overrides

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -38,7 +38,7 @@ pythonPackages.callPackage
       fileCandidates =
         let
           supportedRegex = ("^.*(" + builtins.concatStringsSep "|" supportedExtensions + ")");
-          matchesVersion = fname: builtins.match ("^.*" + builtins.replaceStrings [ "." ] [ "\\." ] version + ".*$") fname != null;
+          matchesVersion = fname: builtins.match ("^.*" + builtins.replaceStrings [ "." "+" ] [ "\\." "\\+" ] version + ".*$") fname != null;
           hasSupportedExtension = fname: builtins.match supportedRegex fname != null;
           isCompatibleEgg = fname: ! lib.strings.hasSuffix ".egg" fname || lib.strings.hasSuffix "py${python.pythonVersion}.egg" fname;
         in

--- a/overrides.nix
+++ b/overrides.nix
@@ -358,6 +358,12 @@ self: super:
     }
   );
 
+  gitpython = super.gitpython.overridePythonAttrs (
+    old: {
+      buildInputs = (old.buildInputs or [ ]) ++ [ self.typing-extensions ];
+    }
+  );
+
   grpcio = super.grpcio.overridePythonAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.cython pkgs.pkg-config ];
     buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.c-ares pkgs.openssl pkgs.zlib ];

--- a/overrides.nix
+++ b/overrides.nix
@@ -568,6 +568,13 @@ self: super:
     }
   );
 
+  jupyterlab-widgets = super.jupyterlab-widgets.overridePythonAttrs (
+    old: rec {
+      buildInputs = (old.buildInputs or [ ]) ++ [ self.jupyter-packaging ];
+    }
+  );
+
+
   keyring = super.keyring.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [

--- a/overrides.nix
+++ b/overrides.nix
@@ -58,6 +58,12 @@ self: super:
     '';
   });
 
+  argcomplete = super.argcomplete.overridePythonAttrs (
+    old: rec {
+      buildInputs = (old.buildInputs or [ ]) ++ [ self.importlib-metadata ];
+    }
+  );
+
   arpeggio = super.arpeggio.overridePythonAttrs (
     old: {
       nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.pytest-runner ];


### PR DESCRIPTION
The `+` symbol was used in the version string of some private packages I depend on.

It seems to be standardised as a way to concatenate extra version information for e.g. local rebuilds: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers