### PR TITLE
fix: add support for wheels files w/ multiple platforms seperated by a period

### DIFF
--- a/pep425.nix
+++ b/pep425.nix
@@ -76,10 +76,11 @@ let
           if targetMachine != null
           then
             (
-              x: x.platform == "manylinux1_${targetMachine}"
-                || x.platform == "manylinux2010_${targetMachine}"
-                || x.platform == "manylinux2014_${targetMachine}"
-                || x.platform == "any"
+              x: x.platform == "any" || lib.lists.any (e: hasInfix e x.platform) [
+                "manylinux1_${targetMachine}"
+                "manylinux2010_${targetMachine}"
+                "manylinux2014_${targetMachine}"
+              ]
             )
           else
             (x: x.platform == "any")


### PR DESCRIPTION
Wheel filenames can have the format "mediapipe-0.8.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl".

Currently the check is for an exact match in the platform bit, i.e. "manylinux_2_17_x86_64.manylinux2014_x86_64".

This change checks whether the platform bit contains the platform we're looking for anywhere in it.

#386 