### PR TITLE
fix: only change shellingham format to pyproject if format is not wheel

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1606,17 +1606,6 @@ self: super:
 
   });
 
-  shellingham =
-    if lib.versionAtLeast super.shellingham.version "1.3.2" then
-      (
-        super.shellingham.overridePythonAttrs (
-          old:
-          if old.format != "wheel" then {
-            format = "pyproject";
-          } else old
-        )
-      ) else super.shellingham;
-
   tables = super.tables.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [ self.pywavelets ];

--- a/overrides.nix
+++ b/overrides.nix
@@ -1611,9 +1611,9 @@ self: super:
       (
         super.shellingham.overridePythonAttrs (
           old:
-            if old.format != "wheel" then {
-              format = "pyproject";
-            } else old
+          if old.format != "wheel" then {
+            format = "pyproject";
+          } else old
         )
       ) else super.shellingham;
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -1610,9 +1610,10 @@ self: super:
     if lib.versionAtLeast super.shellingham.version "1.3.2" then
       (
         super.shellingham.overridePythonAttrs (
-          old: {
-            format = "pyproject";
-          }
+          old:
+            if old.format != "wheel" then {
+              format = "pyproject";
+            } else old
         )
       ) else super.shellingham;
 


### PR DESCRIPTION
When building a Poetry application with `preferWheels = true` and  `shellingham` as a dependency, the override changes the format to `pyproject` but the input to derivation is a `.whl` file. Because the format now is `pyproject`, the wheel hook doesn't run and the build fails.