### PR TITLE
fix: prevent infinite recursion when using tomli

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -96,6 +96,7 @@ pythonPackages.callPackage
         "setuptools_scm"
         "setuptools-scm"
         "toml" # Toml is an extra for setuptools-scm
+        "tomli" # tomli is an extra for later versions of setuptools-scm
       ];
       baseBuildInputs = lib.optional (! lib.elem name skipSetupToolsSCM) pythonPackages.setuptools-scm;
       format = if isDirectory || isGit || isUrl then "pyproject" else fileInfo.format;

--- a/overrides.nix
+++ b/overrides.nix
@@ -2074,7 +2074,7 @@ self: super:
   });
 
   tomli = super.tomli.overridePythonAttrs (old: {
-    buildInputs = (old.buildInputs or [ ]) ++ [ self.flit-core ];
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit-core ];
   });
 
   virtualenv = super.virtualenv.overridePythonAttrs (old: {


### PR DESCRIPTION
This prevents infinite recursion against nixos-unstable-small as of NixOS/nixpkgs@ab126c9a62ca414a933ac19e91d27ddd68cedcd4.
