### PR TITLE
overrides: Fix building black

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -100,6 +100,12 @@ self: super:
     }
   );
 
+  black = super.black.overridePythonAttrs (
+    old: {
+      dontPreferSetupPy = true;
+    }
+  );
+
   borgbackup = super.borgbackup.overridePythonAttrs (
     old: {
       BORG_OPENSSL_PREFIX = pkgs.openssl.dev;


### PR DESCRIPTION
Alternative to https://github.com/nix-community/poetry2nix/pull/388
Closes #375 (which seems unrelated but I can build black on latest nixpkgs unstable with this fix).