### PR TITLE
overrides: add setuptools-scm-git-archive to jira

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -547,6 +547,7 @@ self: super:
         self.pytestrunner
         self.cryptography
         self.pyjwt
+        self.setuptools-scm-git-archive
       ];
     }
   );


### PR DESCRIPTION
This is comparable to #99/#142.