### PR TITLE
README: recommend overriding env over mkShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ in myAppEnv.env
 ```
 
 #### Example shell.nix with external dependencies
-For a shell environment including external dependencies, pass the app environment and dependency packages (for example, `pkgs.hello`) as build inputs to `pkgs.mkShell`.
+For a shell environment including external dependencies, override the `env` to add dependency packages (for example, `pkgs.hello`) as build inputs.
 ```nix
 { pkgs ? import <nixpkgs> {} }:
 let
@@ -120,10 +120,9 @@ let
       my-app = ./src;
     };
   };
-in
-pkgs.mkShell {
-  buildInputs = [ myAppEnv pkgs.hello ];
-}
+in myAppEnv.env.overrideAttrs (oldAttrs: {
+  buildInputs = [ pkgs.hello ]:
+})
 ```
 
 ### mkPoetryPackages


### PR DESCRIPTION
Resolve #186.

The current documentation shows how to include dev-dependencies in
environment *or* add external dependencies to the environment, but I
suspect in the vast majority of cases both will be desired.