### PR TITLE
Override the dontPreferSetupPy attribute for cheroot

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -156,6 +156,12 @@ self: super:
     }
   );
 
+  cheroot = super.cheroot.overridePythonAttrs (
+    old: {
+      dontPreferSetupPy = true;
+    }
+  );
+
   colour = super.colour.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [ self.d2to1 ];


### PR DESCRIPTION
Override the dontPreferSetupPy attribute for cheroot, otherwise it will try to download `setuptools_scm_git_archive` and fail when `sandbox = true`. 