### PR TITLE
fix(zipp): skip patching setup.py if format is wheel

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1854,13 +1854,14 @@ self: super:
     if lib.versionAtLeast super.zipp.version "2.0.0" then
       (
         super.zipp.overridePythonAttrs (
-          old: {
+          old:
+          if (old.format or "pyproject") != "wheel" then {
             prePatch = ''
               substituteInPlace setup.py --replace \
               'setuptools.setup()' \
               'setuptools.setup(version="${super.zipp.version}")'
             '';
-          }
+          } else old
         )
       ) else super.zipp
   ).overridePythonAttrs (


### PR DESCRIPTION
I'm running into another build issue with `preferWheels = true` and `zipp==3.6.0`. Skipping the `setup.py` patch if format is wheel seems to work.