### PR TITLE
Add projectDir to import path for scripts packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -105,7 +105,7 @@ lib.makeScope pkgs.newScope (self: {
     }:
       assert scripts != { };
       import ./shell-scripts.nix {
-        inherit lib python scripts;
+        inherit lib python scripts projectDir;
       };
 
   /*
@@ -130,7 +130,7 @@ lib.makeScope pkgs.newScope (self: {
       scripts = pyProject.tool.poetry.scripts or { };
       hasScripts = scripts != { };
       scriptsPackage = self.mkPoetryScriptsPackage {
-        inherit python scripts;
+        inherit python scripts projectDir;
       };
 
       hasEditable = editablePackageSources != { };
@@ -264,7 +264,7 @@ lib.makeScope pkgs.newScope (self: {
     }:
     let
       poetryPython = self.mkPoetryPackages {
-        inherit pyproject poetrylock overrides python pwd preferWheels editablePackageSources;
+        inherit projectDir pyproject poetrylock overrides python pwd preferWheels editablePackageSources;
       };
 
       inherit (poetryPython) poetryPackages;

--- a/shell-scripts.nix
+++ b/shell-scripts.nix
@@ -1,6 +1,7 @@
 { lib
 , scripts
 , python
+, projectDir ? null
 }:
 let
   mkScript = bin: entrypoint:
@@ -14,6 +15,11 @@ let
       #!${python.interpreter}
       import sys
       import re
+
+      ${lib.optionalString (projectDir != null) ''
+        # Add projectDir to load path
+        sys.path.insert(0, "${builtins.toString projectDir}")
+      ''}
 
       # Insert "" to add CWD to import path
       sys.path.insert(0, "")


### PR DESCRIPTION
This ensures that packages retain their editable property despite not being in the current working directory.