### PR TITLE
Add uwsgi override

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -2083,6 +2083,7 @@ self: super:
 
   uwsgi = super.uwsgi.overridePythonAttrs (old: {
     buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
+    sourceRoot = ".";
   });
 
   virtualenv = super.virtualenv.overridePythonAttrs (old: {

--- a/overrides.nix
+++ b/overrides.nix
@@ -2081,6 +2081,12 @@ self: super:
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit-core ];
   });
 
+  uwsgi = super.uwsgi.overridePythonAttrs (
+    old: rec {
+      buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
+    }
+  );
+
   virtualenv = super.virtualenv.overridePythonAttrs (old: {
     postPatch = ''
       substituteInPlace setup.cfg --replace 'platformdirs>=2,<3' 'platformdirs'

--- a/overrides.nix
+++ b/overrides.nix
@@ -2081,6 +2081,10 @@ self: super:
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit-core ];
   });
 
+  uwsgi = super.uwsgi.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
+  });
+
   virtualenv = super.virtualenv.overridePythonAttrs (old: {
     postPatch = ''
       substituteInPlace setup.cfg --replace 'platformdirs>=2,<3' 'platformdirs'

--- a/overrides.nix
+++ b/overrides.nix
@@ -2081,10 +2081,6 @@ self: super:
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit-core ];
   });
 
-  uwsgi = super.uwsgi.overridePythonAttrs (old: {
-    buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
-  });
-
   virtualenv = super.virtualenv.overridePythonAttrs (old: {
     postPatch = ''
       substituteInPlace setup.cfg --replace 'platformdirs>=2,<3' 'platformdirs'

--- a/overrides.nix
+++ b/overrides.nix
@@ -2081,11 +2081,9 @@ self: super:
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit-core ];
   });
 
-  uwsgi = super.uwsgi.overridePythonAttrs (
-    old: rec {
-      buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
-    }
-  );
+  uwsgi = super.uwsgi.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
+  });
 
   virtualenv = super.virtualenv.overridePythonAttrs (old: {
     postPatch = ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -59,6 +59,7 @@ builtins.removeAttrs
   mk-poetry-packages = callTest ./mk-poetry-packages { };
   markupsafe2 = callTest ./markupsafe2 { };
   pendulum = callTest ./pendulum { };
+  uwsgi = callTest ./uwsgi { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/uwsgi/default.nix
+++ b/tests/uwsgi/default.nix
@@ -1,0 +1,6 @@
+{ lib, poetry2nix, runCommand }:
+poetry2nix.mkPoetryApplication {
+  pyproject = ./pyproject.toml;
+  poetrylock = ./poetry.lock;
+  src = lib.cleanSource ./.;
+}

--- a/tests/uwsgi/poetry.lock
+++ b/tests/uwsgi/poetry.lock
@@ -1,0 +1,17 @@
+[[package]]
+name = "uwsgi"
+version = "2.0.19.1"
+description = "The uWSGI server"
+category = "main"
+optional = false
+python-versions = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "ec1973a5762a2a84e937c4d4712774561a9ddbbe91905a20053e4890176f1a33"
+
+[metadata.files]
+uwsgi = [
+    {file = "uWSGI-2.0.19.1.tar.gz", hash = "sha256:faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869"},
+]

--- a/tests/uwsgi/pyproject.toml
+++ b/tests/uwsgi/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "test_uwsgi"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.8"
+uwsgi = "^2.0.19"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
This adds an uwsgi override that resolved a build issue on my own project. 

I also tried adding tests, I copied the example of `pendulum`, but I was unable to run the tests locally. `nix-build --keep-going --show-trace tests/default.nix` hangs for me on this output:
```
building '/nix/store/wzm0xa83yldljcd4c27kwzl1yyhp9vxw-app-env-test.drv'...
[2021-10-04 16:41:55 +0000] [54167] [INFO] Starting gunicorn 19.10.0
[2021-10-04 16:41:55 +0000] [54167] [INFO] Listening at: unix:socket (54167)
[2021-10-04 16:41:55 +0000] [54167] [INFO] Using worker: sync
/nix/store/5vn5f6slfg1nw8q0bhapd3vgk9j7559i-python3-3.8.7/lib/python3.8/os.py:1023: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  return io.open(fd, *args, **kwargs)
[2021-10-04 16:41:55 +0000] [54170] [INFO] Booting worker with pid: 54170
Hello, World!
```

First PR (on any nix repo), apologies for any obvious mistakes 🙏.