### PR TITLE
fetchGit: work-around bug in Nix 2.4

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -163,11 +163,18 @@ pythonPackages.callPackage
       src =
         if isGit then
           (
-            builtins.fetchGit {
+            builtins.fetchGit ({
               inherit (source) url;
               rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or sourceSpec.rev or (if sourceSpec?tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
-            }
+            } // (
+              let
+                nixVersion = builtins.substring 0 3 builtins.nixVersion;
+              in
+              lib.optionalAttrs (lib.versionAtLeast nixVersion "2.4") {
+                allRefs = true;
+              }
+            ))
           )
         else if isUrl then
           builtins.fetchTarball

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -166,12 +166,12 @@ pythonPackages.callPackage
             builtins.fetchGit ({
               inherit (source) url;
               rev = source.resolved_reference or source.reference;
-              ref = sourceSpec.branch or sourceSpec.rev or (if sourceSpec?tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
+              ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             } // (
               let
                 nixVersion = builtins.substring 0 3 builtins.nixVersion;
               in
-              lib.optionalAttrs (lib.versionAtLeast nixVersion "2.4") {
+              lib.optionalAttrs ((sourceSpec ? rev) && (lib.versionAtLeast nixVersion "2.4")) {
                 allRefs = true;
               }
             ))


### PR DESCRIPTION
Another approach to make `poetry2nix` work with dependencies specified
by arbitrary `rev=<hash>` values on newer Nix revisions.

Relates-to: https://github.com/nix-community/poetry2nix/pull/358
Relates-to: https://github.com/NixOS/nix/issues/5128

--
~Interestingly I only see this error on 'nix-2.4pre20211001_4f49615' (nixpkgs-unstable channel) but not on 'nix-2.5pre20211007_844dd90' (nixos-unstable channel)~
**Update**: there was a cached copy of that dependency in my /nix/store :upside_down_face: 