### PR TITLE
Revert "feat: Re-enable mypyc from version 0.910"

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -870,10 +870,7 @@ self: super:
         # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
         stdenv.buildPlatform.is64bit
         # Derivation fails to build since v0.900 if mypyc is enabled.
-        && (
-          lib.strings.versionOlder old.version "0.900"
-          || lib.strings.versionAtLeast old.version "0.910"
-        );
+        && lib.strings.versionOlder old.version "0.900";
     }
   );
 


### PR DESCRIPTION
See discussion on
<https://github.com/nix-community/poetry2nix/pull/428>.

This reverts commit 0b9f3e19f43c3081a9c14cad7b2ed6f1668b7b9a.