### PR TITLE
importlib-resources: Don't remove pyproject.toml

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -548,6 +548,13 @@ self: super:
     }
   );
 
+  importlib-resources = super.importlib-resources.overridePythonAttrs (
+    old: {
+      # disable the removal of pyproject.toml, required because of setuptools_scm
+      dontPreferSetupPy = true;
+    }
+  );
+
   intreehooks = super.intreehooks.overridePythonAttrs (
     old: {
       doCheck = false;


### PR DESCRIPTION
Without this change the build of jsonschema-4.2.1 fails with:

> ERROR: Could not find a version that satisfies the requirement importlib-resources>=1.4.0; python_version < "3.9" (from jsonschema)
> ERROR: No matching distribution found for importlib-resources>=1.4.0; python_version < "3.9"

The problem seems to be similar to #294, and the same fix seems to work.