### PR TITLE
Include the trailing slash in legacy index URL

### DIFF
--- a/fetch_from_legacy.py
+++ b/fetch_from_legacy.py
@@ -39,7 +39,7 @@ class Pep503(HTMLParser):
 
 url = sys.argv[1]
 package_name = sys.argv[2]
-index_url = url + "/" + package_name
+index_url = url + "/" + package_name + "/"
 package_filename = sys.argv[3]
 
 print("Reading index %s" % index_url)


### PR DESCRIPTION
The [PyPI Legacy API documentation][1] says that the distribution downloads for project can be accessed via a request

    GET /simple/<project>/

but the current implementation instead makes a request

    GET /simple/<project>

There exist some custom repository servers that give erroneous responses to requests without the slash, so include the slash.

[1]: https://warehouse.pypa.io/api-reference/legacy.html