### PR TITLE
overrides: matplotlib: fix for version >= 3.5.0

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -766,10 +766,15 @@ self: super:
 
       nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
         pkgs.pkg-config
+      ] ++ lib.optional (lib.versionAtLeast super.matplotlib.version "3.5.0") [
+        self.setuptools-scm
+        self.setuptools-scm-git-archive
       ];
 
       postPatch = ''
-        cat > setup.cfg <<EOF
+        cat > '' +
+      (if lib.versionAtLeast super.matplotlib.version "3.5.0" then "mplsetup.cfg" else "setup.cfg") +
+      '' <<EOF
         [libs]
         system_freetype = True
         system_qhull = True


### PR DESCRIPTION
Packaging-relevant changes in matplotlib 3.5.0:
- `setup.cfg` was renamed `mplsetup.cfg` ([changelog](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#matplotlib-specific-build-options-moved-from-setup-cfg-to-mplsetup-cfg), matplotlib/matplotlib#20871)
- `setuptools_scm` is used instead of `versioneer`(matplotlib/matplotlib#18971).

Updated the override accordingly.