### PR TITLE
overrides: wtforms: add

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -2117,4 +2117,8 @@ self: super:
     buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
     sourceRoot = ".";
   });
+
+  wtforms = super.wtforms.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.Babel ];
+  });
 }


### PR DESCRIPTION
Add override for [`WTForms`](https://pypi.org/project/WTForms/):

- add `buildInputs` override for [`setup_requires=Babel`](https://github.com/wtforms/wtforms/blob/0beff0b5c29f4995ea1c573d3c1d043471b6e1c3/setup.cfg#L30)
- tested against 3.0.0