### PR TITLE
overrides: scipy: fix for version >= 1.7.0

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1582,7 +1582,9 @@ self: super:
   scipy = super.scipy.overridePythonAttrs (
     old:
     if old.format != "wheel" then {
-      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.gfortran ];
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++
+        [ pkgs.gfortran ] ++
+        lib.optional (lib.versionAtLeast super.scipy.version "1.7.0") [ self.cython self.pythran ];
       propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.pybind11 ];
       setupPyBuildFlags = [ "--fcompiler='gnu95'" ];
       enableParallelBuilding = true;


### PR DESCRIPTION
Since version 1.7.0, the Pythran transpiler is [enabled by default](https://scipy.github.io/devdocs/release.1.7.0.html#other-changes) when building `scipy`.