### PR TITLE
overrides: argon2-cffi: fix for version >= 21.2.0

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -85,6 +85,13 @@ self: super:
     }
   );
 
+  argon2-cffi = super.argon2-cffi.overridePythonAttrs (
+    old: {
+      buildInputs = (old.buildInputs or [ ]) ++
+        lib.optional (lib.versionAtLeast old.version "21.2.0") [ self.flit-core ];
+    }
+  );
+
   backports-entry-points-selectable = super.backports-entry-points-selectable.overridePythonAttrs (old: {
     postPatch = ''
       substituteInPlace setup.py --replace \


### PR DESCRIPTION
[`argon2-cffi`](https://pypi.org/project/argon2-cffi/) migrated to `flit` at hynek/argon2-cffi@cb0248d29ab20784ffe26d969bb43aa91fade1c2 which was integrated into the 21.2.0 release.