### PR TITLE
overrides: matplotlib: use MPLSETUPCFG

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -779,7 +779,7 @@ self: super:
         self.setuptools-scm-git-archive
       ];
 
-      MPLSETUPCFG = writeText "mplsetup.cfg" ''
+      MPLSETUPCFG = pkgs.writeText "mplsetup.cfg" ''
         [libs]
         system_freetype = True
         system_qhull = True

--- a/overrides.nix
+++ b/overrides.nix
@@ -779,18 +779,13 @@ self: super:
         self.setuptools-scm-git-archive
       ];
 
-      postPatch = ''
-        cat > '' +
-      (if lib.versionAtLeast super.matplotlib.version "3.5.0" then "mplsetup.cfg" else "setup.cfg") +
-      '' <<EOF
+      MPLSETUPCFG = writeText "mplsetup.cfg" ''
         [libs]
         system_freetype = True
         system_qhull = True
       '' + lib.optionalString stdenv.isDarwin ''
         # LTO not working in darwin stdenv, see NixOS/nixpkgs/pull/19312
         enable_lto = false
-      '' + ''
-        EOF
       '';
 
       propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [


### PR DESCRIPTION
Hi! Friendly upstream here. We made some change[1] that will make your `postPatch` override ineffective. This should make a backwards-compatible change to correct that. Also, I'm not a poetry user, so this is untested. I hope you can help me with that.

cc @K900

[1] https://github.com/NixOS/nixpkgs/commit/7dc44307515de130daf661814891d8844fdf701f