### PR TITLE
build: remove bootstrap dependency on poetry

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -129,7 +129,6 @@ pythonPackages.callPackage
         ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) pythonPackages.setuptools
         ++ lib.optional (!isSource) (getManyLinuxDeps fileInfo.name).pkg
         ++ lib.optional isDirectory buildSystemPkgs
-        ++ lib.optional (!__isBootstrap) pythonPackages.poetry
       );
 
       propagatedBuildInputs =

--- a/overrides.nix
+++ b/overrides.nix
@@ -2103,7 +2103,7 @@ self: super:
   );
 
   pendulum = super.pendulum.overridePythonAttrs (old: {
-    buildInputs = (old.buildInputs or []) ++ [ self.poetry ];
+    buildInputs = (old.buildInputs or [ ]) ++ [ self.poetry ];
     # Technically incorrect, but fixes the build error..
     preInstall = lib.optionalString stdenv.isLinux ''
       mv --no-clobber ./dist/*.whl $(echo ./dist/*.whl | sed s/'manylinux_[0-9]*_[0-9]*'/'manylinux1'/)

--- a/overrides.nix
+++ b/overrides.nix
@@ -2103,6 +2103,7 @@ self: super:
   );
 
   pendulum = super.pendulum.overridePythonAttrs (old: {
+    buildInputs = (old.buildInputs or []) ++ [ self.poetry ];
     # Technically incorrect, but fixes the build error..
     preInstall = lib.optionalString stdenv.isLinux ''
       mv --no-clobber ./dist/*.whl $(echo ./dist/*.whl | sed s/'manylinux_[0-9]*_[0-9]*'/'manylinux1'/)


### PR DESCRIPTION
This PR removes a dependency on `poetry` that gets put into most dependencies
as a `buildInputs` if poetry2nix isn't bootstrapping, which if I'm reading the
code correctly is nearly everywhere (`__isBootstrap` is `false` by default).

This is a problem when building using `crossSystem` (I'm trying to
build a Docker image using musl) because any dependency that overlapped with
`poetry`'s dependencies would cause both the build *and* host platform versions
of poetry's deps to be installed, causing a conflict during build.

It also appears that this bootstrap dependency is not necessary, at least
according to the current test suite. The only package that needed modification
was `pendulum`.
