### PR TITLE
fix: remove double build of arrow-cpp when self.python != self.python3

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1122,11 +1122,8 @@ self: super:
             PARQUET_HOME = _arrow-cpp;
             inherit ARROW_HOME;
 
-            buildInputs = (old.buildInputs or [ ]) ++ [
-              _arrow-cpp
-            ];
-
             PYARROW_BUILD_TYPE = "release";
+            PYARROW_WITH_FLIGHT = _arrow-cpp.enableFlight;
             PYARROW_WITH_DATASET = true;
             PYARROW_WITH_PARQUET = true;
             PYARROW_CMAKE_OPTIONS = [

--- a/overrides.nix
+++ b/overrides.nix
@@ -1103,7 +1103,7 @@ self: super:
             );
 
             ARROW_HOME = _arrow-cpp;
-            arrowCppVersion = parseMinor pkgs.arrow-cpp;
+            arrowCppVersion = parseMinor _arrow-cpp;
             pyArrowVersion = parseMinor super.pyarrow;
             errorMessage = "arrow-cpp version (${arrowCppVersion}) mismatches pyarrow version (${pyArrowVersion})";
           in

--- a/overrides.nix
+++ b/overrides.nix
@@ -1123,7 +1123,7 @@ self: super:
             inherit ARROW_HOME;
 
             buildInputs = (old.buildInputs or [ ]) ++ [
-              pkgs.arrow-cpp
+              _arrow-cpp
             ];
 
             PYARROW_BUILD_TYPE = "release";

--- a/overrides.nix
+++ b/overrides.nix
@@ -1123,7 +1123,7 @@ self: super:
             inherit ARROW_HOME;
 
             PYARROW_BUILD_TYPE = "release";
-            PYARROW_WITH_FLIGHT = _arrow-cpp.enableFlight;
+            PYARROW_WITH_FLIGHT = if _arrow-cpp.enableFlight then 1 else 0;
             PYARROW_WITH_DATASET = 1;
             PYARROW_WITH_PARQUET = 1;
             PYARROW_CMAKE_OPTIONS = [

--- a/overrides.nix
+++ b/overrides.nix
@@ -1124,8 +1124,8 @@ self: super:
 
             PYARROW_BUILD_TYPE = "release";
             PYARROW_WITH_FLIGHT = _arrow-cpp.enableFlight;
-            PYARROW_WITH_DATASET = true;
-            PYARROW_WITH_PARQUET = true;
+            PYARROW_WITH_DATASET = 1;
+            PYARROW_WITH_PARQUET = 1;
             PYARROW_CMAKE_OPTIONS = [
               "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"
 


### PR DESCRIPTION
- fix: ensure that arrow-cpp isn't built twice when python3 != python
- refactor: remove _arrow-cpp from buildInputs
- build: minimize use of pkgs.arrow-cpp

`arrow-cpp` is built twice when `self.python != self.python3`, because of the override to `_arrow-cpp`, and then later use of `pkgs.arrow-cpp`. This PR moves everything to use the override.