### PR TITLE
mkPoetryEnv: Add an extraPackages argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Creates an environment that provides a Python interpreter along with all depende
 - **overrides**: Python overrides to apply (_default_: `[defaultPoetryOverrides]`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
 - **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
+- **extraPackages**: A function taking a Python package set and returning a list of extra packages to include in the environment. This is intended for packages deliberately not added to `pyproject.toml` that you still want to include. An example of such a package may be `pip`. (_default:_ `(ps: [ ])`).
 
 #### Example
 ```nix

--- a/default.nix
+++ b/default.nix
@@ -261,6 +261,7 @@ lib.makeScope pkgs.newScope (self: {
     , python ? pkgs.python3
     , preferWheels ? false
     , editablePackageSources ? { }
+    , extraPackages ? ps: [ ]
     }:
     let
       poetryPython = self.mkPoetryPackages {
@@ -270,7 +271,7 @@ lib.makeScope pkgs.newScope (self: {
       inherit (poetryPython) poetryPackages;
 
     in
-    poetryPython.python.withPackages (_: poetryPackages);
+    poetryPython.python.withPackages (ps: poetryPackages ++ (extraPackages ps));
 
   /* Creates a Python application from pyproject.toml and poetry.lock
 


### PR DESCRIPTION
This is a function taking a Python package set and returning a list of extra packages to include in the environment. 
This is intended for packages deliberately not added to `pyproject.toml` that you still want to include.
An example of such a package may be `pip`.