### PR TITLE
Add dependabot configuration to update Poetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Auto-update the Poetry package, but not tests
+  - package-ecosystem: "pip"
+    directory: "/pkgs"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
But we don't want to auto-bump tests for obvious reasons.