### PR TITLE
Create a dummy null package for the current project in case any dependencies depend on the root project

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -272,9 +272,14 @@ lib.makeScope pkgs.newScope (self: {
       };
 
       inherit (poetryPython) poetryPackages;
+      inherit (lib) elem;
+
+      # Don't add editable sources to the environment since they will sometimes fail to build and are not useful in the development env
+      editableAttrs = lib.attrNames editablePackageSources;
+      envPkgs = builtins.filter (drv: ! lib.elem (drv.pname or drv.name or "") editableAttrs) poetryPackages;
 
     in
-    poetryPython.python.withPackages (ps: poetryPackages ++ (extraPackages ps));
+    poetryPython.python.withPackages (ps: envPkgs ++ (extraPackages ps));
 
   /* Creates a Python application from pyproject.toml and poetry.lock
 

--- a/default.nix
+++ b/default.nix
@@ -190,7 +190,10 @@ lib.makeScope pkgs.newScope (self: {
               (lib.reverseList compatible)
           );
         in
-        lockPkgs;
+        lockPkgs // {
+          # Create a dummy null package for the current project in case any dependencies depend on the root project (issue #307)
+          ${pyProject.tool.poetry.name} = null;
+        };
       overlays = builtins.map
         getFunctorFn
         (


### PR DESCRIPTION
This isn't quite done as the dependency build fails because it's missing the dependency, but at least evaluation passes.