### PR TITLE
Add path dependencies where develop=true as editable packages by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates an environment that provides a Python interpreter along with all depende
 - **poetrylock**: `poetry.lock` file path (_default_: `projectDir + "/poetry.lock"`).
 - **overrides**: Python overrides to apply (_default_: `[defaultPoetryOverrides]`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
-- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode (_default:_ `{}`).
+- **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode. Note that path dependencies with `develop = true` will be installed in editable mode unless explicitly passed to `editablePackageSources` as `null`.  (_default:_ `{}`).
 - **extraPackages**: A function taking a Python package set and returning a list of extra packages to include in the environment. This is intended for packages deliberately not added to `pyproject.toml` that you still want to include. An example of such a package may be `pip`. (_default:_ `(ps: [ ])`).
 
 #### Example

--- a/default.nix
+++ b/default.nix
@@ -133,9 +133,11 @@ lib.makeScope pkgs.newScope (self: {
         inherit python scripts;
       };
 
-      hasEditable = editablePackageSources != { };
+      editablePackageSources' = lib.filterAttrs (name: path: path != null) editablePackageSources;
+      hasEditable = editablePackageSources' != { };
       editablePackage = self.mkPoetryEditablePackage {
-        inherit pyProject python editablePackageSources;
+        inherit pyProject python;
+        editablePackageSources = editablePackageSources';
       };
 
       poetryLock = readTOML poetrylock;


### PR DESCRIPTION
This removes a lot of boilerplate from Nix code and I think that this is the expected behaviour.

~We might want to have a mechanism to _exclude_ some packages from being editable.~
~Maybe simply explicitly setting the editable path to `null` would suffice?~
This is now implemented in the second commit of this PR.