### PR TITLE
make wheel selection more sophisticated for m1 macs

### DIFF
--- a/pep425.nix
+++ b/pep425.nix
@@ -84,7 +84,13 @@ let
             )
           else
             (x: x.platform == "any")
-        else (x: hasInfix "macosx" x.platform || x.platform == "any");
+        else
+          if stdenv.isDarwin
+          then
+            if stdenv.targetPlatform.isAarch64
+            then (x: x.platform == "any" || ((hasInfix "macosx" x.platform) && lib.lists.any (e: hasSuffix e x.platform) [ "arm64" "aarch64" ]))
+            else (x: x.platform == "any" || ((hasInfix "macosx" x.platform) && hasSuffix "x86_64" x.platform))
+          else (x: x.platform == "any");
       filterWheel = x:
         let
           f = toWheelAttrs x.file;
@@ -93,7 +99,7 @@ let
       filtered = builtins.filter filterWheel filesWithoutSources;
       choose = files:
         let
-          osxMatches = [ "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
+          osxMatches = [ "12_0" "11_0" "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
           linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "any" ];
           chooseLinux = x: lib.take 1 (findBestMatches linuxMatches x);
           chooseOSX = x: lib.take 1 (findBestMatches osxMatches x);

--- a/pep425.nix
+++ b/pep425.nix
@@ -88,8 +88,8 @@ let
           if stdenv.isDarwin
           then
             if stdenv.targetPlatform.isAarch64
-            then (x: x.platform == "any" || ((hasInfix "macosx" x.platform) && lib.lists.any (e: hasSuffix e x.platform) [ "arm64" "aarch64" ]))
-            else (x: x.platform == "any" || ((hasInfix "macosx" x.platform) && hasSuffix "x86_64" x.platform))
+            then (x: x.platform == "any" || (hasInfix "macosx" x.platform && lib.lists.any (e: hasSuffix e x.platform) [ "arm64" "aarch64" ]))
+            else (x: x.platform == "any" || (hasInfix "macosx" x.platform && hasSuffix "x86_64" x.platform))
           else (x: x.platform == "any");
       filterWheel = x:
         let


### PR DESCRIPTION
This is an attempt to make the wheel selection work in a more precise way on aarch64 darwin platforms. The motivating example was trying to install pytorch: https://pypi.org/project/torch/#files. The current version of poetry2nix was selecting `torch-1.10.1-cp39-none-macosx_10_9_x86_64.whl` which is incompatible with the arm infrastructure. This PR will filter out any wheels which don't match the target architecture.

Note: I am quite new to nix/poetry2nix so I may not have done this in the most idiomatic way. I also don't have a non-m1 mac to hand to double check I haven't accidentally broken things on there.