### PR TITLE
Adds pbr to requests-mock.propagatedInputs

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1622,6 +1622,12 @@ self: super:
     }
   );
 
+  requests-mock = super.requests-mock.overridePythonAttrs (
+    old: {
+      propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ super.pbr ];
+    }
+  );
+
   requests-unixsocket = super.requests-unixsocket.overridePythonAttrs (
     old: {
       nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.pbr ];


### PR DESCRIPTION
Adds `pbr` as a propagated build input to `requests-mock`.

I'm able to successfully build a poetry2nix package with change. It doesn't look like we add tests for every override, but I'm happy to add tests as needed.