### PR TITLE
overrides: fix opencv-contrib-python the same way as opencv-python

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1032,6 +1032,14 @@ self: super:
     }
   );
 
+  opencv-contrib-python = super.opencv-contrib-python.overridePythonAttrs (
+    old: {
+      nativeBuildInputs = [ pkgs.cmake ] ++ old.nativeBuildInputs;
+      buildInputs = [ self.scikit-build ] ++ (old.buildInputs or [ ]);
+      dontUseCmakeConfigure = true;
+    }
+  );
+
   openexr = super.openexr.overridePythonAttrs (
     old: rec {
       buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.openexr pkgs.ilmbase ];


### PR DESCRIPTION
It's required by [webcam-filters](https://github.com/jashandeep-sohi/webcam-filters), I tested it [here](https://github.com/kurnevsky/nixfiles/blob/1e2a0dff9eb1477aea7563556783bd74e8cc7c99/modules/webcam-filters.nix#L22).