### PR TITLE
tests: Add test for IFD projectDir

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -409,6 +409,13 @@ self: super:
     }
   );
 
+  fastapi = super.fastapi.overridePythonAttrs (
+    old: {
+      # Note: requires full flit, not just flit-core
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.flit ];
+    }
+  );
+
   fastecdsa = super.fastecdsa.overridePythonAttrs (old: {
     buildInputs = old.buildInputs ++ [ pkgs.gmp.dev ];
   });
@@ -1380,6 +1387,7 @@ self: super:
           pkgs.qt5.qtsvg
           pkgs.qt5.qtdeclarative
           pkgs.qt5.qtwebchannel
+          pkgs.qt5.qt3d
           # self.pyqt5-sip
           self.sip
         ]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -63,6 +63,7 @@ builtins.removeAttrs
   jq = callTest ./jq { };
   awscli = callTest ./awscli { };
   aiopath = callTest ./aiopath { };
+  fetched-projectdir = callTest ./fetched-projectdir { };
 
   # Test building poetry
   inherit poetry;

--- a/tests/fetched-projectdir/default.nix
+++ b/tests/fetched-projectdir/default.nix
@@ -1,0 +1,11 @@
+{ lib, poetry2nix, python39, fetchFromGitHub }:
+
+poetry2nix.mkPoetryApplication {
+  projectDir = fetchFromGitHub {
+    owner = "schemathesis";
+    repo = "schemathesis";
+    rev = "v3.12.1";
+    sha256 = "sha256-iU1tsA9MKKH/zjuBxD5yExJOPoL2V/OG3WYc9w0do9I=";
+  };
+  python = python39;
+}


### PR DESCRIPTION
This fixes the build for `fastapi` which requires `flit` as a build input and adds a test for IFD projectDir which was added in f3f70444b7ec8dfbb1867d8fa99c6cff1fb7f139 without a test case.

cc @manveru 