### PR TITLE
The package URL is relative to the index URL

### DIFF
--- a/fetch_from_legacy.py
+++ b/fetch_from_legacy.py
@@ -84,7 +84,7 @@ if urlparse(parser.sources[package_filename]).netloc == '':
     package_url = urlunparse((
         parsed_url.scheme,
         parsed_url.netloc,
-        parser.sources[package_filename],
+        parsed_url.path + "/" + parser.sources[package_filename],
         None, None, None,
     ))
 else:


### PR DESCRIPTION
This fixes a regression introduced by f7ab15e390653988bcf941790a411cabfd8527b4.

In case of a devpi repository,
- the index url looks like

    https://devpi.company/company/dev/+simple/python-package

- the package relative URL looks like

    /../../+f/d00/a3edd114f3e81/package.tar.gz#sha256=d00a3edd114f3e813e0e22e07513361b00d925fb67057a3452a897c8623f73f6

- the URL to download the package is

    https://devpi.company/company/dev/+f/d00/a3edd114f3e81/package.tar.gz#sha256=d00a3edd114f3e813e0e22e07513361b00d925fb67057a3452a897c8623f73f6

With the commit f7ab15e390653988bcf941790a411cabfd8527b4, the URL to
download the package was

    https://devpi.company/+f/d00/a3edd114f3e81/package.tar.gz#sha256=d00a3edd114f3e813e0e22e07513361b00d925fb67057a3452a897c8623f73f6

which doesn't exist.

@rskew since you authored f7ab15e390653988bcf941790a411cabfd8527b4, could you take a look at this PR?