### PR TITLE
overrides: add scikit-image

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1700,6 +1700,18 @@ self: super:
     } else old
   );
 
+  scikit-image = super.scikit-image.overridePythonAttrs (
+    old: {
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+        self.cython
+        self.pythran
+        self.packaging
+        self.wheel
+        self.numpy
+      ];
+    }
+  );
+
   scikit-learn = super.scikit-learn.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [


### PR DESCRIPTION
scikit-image has a `requirements/build.txt` that does not get picked up automatically. This adds the listed requirements manually to `nativeBuildInputs`. I don't know if that's the best approach, but it builds.