### PR TITLE
Remove rec from template

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -24,11 +24,11 @@
           overlays = [ self.overlay ];
         };
       in
-      rec {
+      {
         apps = {
           myapp = pkgs.myapp;
         };
 
-        defaultApp = apps.myapp;
+        defaultApp = pkgs.myapp;
       }));
 }


### PR DESCRIPTION
It seems this is an anti-pattern, according to https://nix.dev/anti-patterns/language#rec-expression.

So, I suggest to remove it from there. Better not ship anti-patterns on templates, isn't it?