### PR TITLE
Add overlay that disables checks for packages inherited from nixpkgs

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -1362,11 +1362,6 @@ self: super:
     }
   );
 
-  pyparsing = super.pyparsing.overridePythonAttrs (old: {
-    # Prevent infinite recursion since checkInputs brings in coverage which in turn depends on pyparsing
-    doCheck = false;
-  });
-
   pyproject-flake8 = super.pyproject-flake8.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [ self.flit-core ];


### PR DESCRIPTION
This is a more principled fix to https://github.com/nix-community/poetry2nix/pull/510 that will hopefully prevent this entire class of errors.