### PR TITLE
Skip build jobs in CI if already cached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           echo "::set-output name=matrix::$matrix"
 
   builds:
-    if: ${{ matrix.cached }} != true
+    if: false
     needs: matrix_generate
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          matrix="$(nix-instantiate --eval --json --expr 'builtins.attrNames (import ./tests {})' | jq -rcM '{attr: ., os: ["ubuntu-latest", "macos-latest"]}')"
+          matrix="$(nix-instantiate --eval --json --expr 'builtins.attrNames (import ./tests {})' | jq -rcM '{attr: ., cached: true, os: ["ubuntu-latest", "macos-latest"]}')"
           echo "::set-output name=matrix::$matrix"
 
   builds:
+    if: ${{ matrix.cached }} != true
     needs: matrix_generate
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           echo "::set-output name=matrix::$matrix"
 
   builds:
-    if: false
+    if: !matrix.cached
     needs: matrix_generate
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Waiting times right now are pretty high and most jobs are cache hits anyway.
Let's skip jobs that are cached and make the Github scheduler aware of that.