### PR TITLE
Compile mypy once again

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -973,11 +973,25 @@ lib.composeManyExtensions [
 
       mypy = super.mypy.overridePythonAttrs (
         old: {
-          MYPY_USE_MYPYC =
-            # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
-            stdenv.buildPlatform.is64bit
-            # Derivation fails to build since v0.900 if mypyc is enabled.
-            && lib.strings.versionOlder old.version "0.900";
+          patches = (old.patches or [ ]) ++ lib.optionals (lib.strings.versionAtLeast old.version "0.900") [
+            # FIXME: Remove patch after upstream has decided the proper solution.
+            #        https://github.com/python/mypy/pull/11143
+            (pkgs.fetchpatch {
+              url = "https://github.com/python/mypy/commit/f1755259d54330cd087cae763cd5bbbff26e3e8a.patch";
+              sha256 = "sha256-5gPahX2X6+/qUaqDQIGJGvh9lQ2EDtks2cpQutgbOHk=";
+            })
+          ];
+          buildInputs = (old.buildInputs or [ ]) ++ [
+            self.types-typed-ast
+          ];
+          # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled
+          # version is also the default in the wheels on Pypi that include binaries.
+          # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
+          MYPY_USE_MYPYC = stdenv.buildPlatform.is64bit;
+
+          # when testing reduce optimisation level to drastically reduce build time
+          # (default is 3)
+          # MYPYC_OPT_LEVEL = 1;
         }
       );
 


### PR DESCRIPTION
So last time we disabled compilation, because it was broken since release of 0.900: https://github.com/nix-community/poetry2nix/issues/323

Looks like things blocking it got resolved and it could be enabled once again. This will increase build time, but then produce a much faster version of mypy.

Compilation could be disabled once again by overriding:
```
MYPY_USE_MYPYC=0
```

or time spent could be reduced by:
```
MYPYC_OPT_LEVEL=<value between 0 and 3>
```