### PR TITLE
overrides.uwsgi: only change sourceRoot for 2.0.19.x

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2153,10 +2153,13 @@ lib.composeManyExtensions [
         buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools-scm-git-archive ];
       });
 
-      uwsgi = super.uwsgi.overridePythonAttrs (old: {
-        buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
-        sourceRoot = ".";
-      });
+      uwsgi = super.uwsgi.overridePythonAttrs
+        (old:
+          {
+            buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];
+          } // lib.optionalAttrs (lib.versionAtLeast old.version "2.0.19" && lib.versionOlder old.version "2.0.20") {
+            sourceRoot = ".";
+          });
 
       wcwidth = super.wcwidth.overridePythonAttrs (old: {
         propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++


### PR DESCRIPTION
Checking the tarballs on pypi, it seems this override is only needed for 2.0.19.x release series. Applying it to other releases causes the build to fail.