### PR TITLE
Add hook to remove normal files from site-packages

### DIFF
--- a/hooks/default.nix
+++ b/hooks/default.nix
@@ -67,6 +67,13 @@ in
         {
           name = "fixup-hook.sh";
           deps = [ ];
+          substitutions = {
+            inherit pythonSitePackages;
+            filenames = builtins.concatStringsSep " " [
+              "pyproject.toml"
+              "README.md"
+            ];
+          };
         } ./fixup-hook.sh
     )
     { };

--- a/hooks/fixup-hook.sh
+++ b/hooks/fixup-hook.sh
@@ -1,8 +1,20 @@
 poetry2nix-fixup-hook() {
+
     # Including tests in the output is a common mistake
     if [ -z "${dontFixupTests-}" ]; then
-        rm -rf $out/lib/python3.7/site-packages/tests
+        rm -rf $out/@pythonSitePackages@/tests
     fi
+
+    # Including files in site-packages is a common packaging mistake
+    #
+    # While we cannot remove all normal files dumped in site-packages
+    # we can clean up some common mistakes
+    if [ -z "${dontFixupSitePackages-}" ]; then
+        for f in @filenames@; do
+            rm -f $out/@pythonSitePackages@/$f
+        done
+    fi
+
 }
 
 postFixupHooks+=(poetry2nix-fixup-hook)


### PR DESCRIPTION
This is a fairly common packaging mistake that it's better that we solve in a hook than in one-by-one in overrides.