### PR TITLE
overrides.python-magic: patch libmagic path

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1571,6 +1571,16 @@ lib.composeManyExtensions [
         }
       );
 
+      python-magic = super.python-magic.overridePythonAttrs (
+        old: {
+          postPatch = ''
+            substituteInPlace magic/loader.py \
+              --replace "'libmagic.so.1'" "'${lib.getLib pkgs.file}/lib/libmagic.so.1'"
+          '';
+          pythonImportsCheck = old.pythonImportsCheck or [ ] ++ [ "magic" ];
+        }
+      );
+
       python-olm = super.python-olm.overridePythonAttrs (
         old: {
           buildInputs = old.buildInputs or [ ] ++ [ pkgs.olm ];


### PR DESCRIPTION
Also add an importscheck for the "magic" module. Without this override,
an error such as this occurs:

>   ImportError: failed to find libmagic.  Check your installation