### PR TITLE
overrides.pymediainfo: patch libmediainfo paths

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1353,6 +1353,20 @@ lib.composeManyExtensions [
         }
       );
 
+      pymediainfo = super.pymediainfo.overridePythonAttrs (
+        old: {
+          postPatch = (old.postPatch or "") + ''
+            substituteInPlace pymediainfo/__init__.py \
+              --replace "libmediainfo.0.dylib" \
+                        "${pkgs.libmediainfo}/lib/libmediainfo.0${stdenv.hostPlatform.extensions.sharedLibrary}" \
+              --replace "libmediainfo.dylib" \
+                        "${pkgs.libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}" \
+              --replace "libmediainfo.so.0" \
+                        "${pkgs.libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}.0"
+          '';
+        }
+      );
+
       pymssql = super.pymssql.overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ])
           ++ [ pkgs.openssl ];


### PR DESCRIPTION
https://pypi.org/project/pymediainfo/

This code is taken from nixpkgs https://github.com/nagy/nixpkgs/blob/6f02ba937a5df77d0a7ae5b3748a55599a96c1df/pkgs/development/python-modules/pymediainfo/default.nix#L15-L23