### PR TITLE
overrides.entrypoints: entrypoints only requires flit-core

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -262,7 +262,7 @@
     "poetry-core"
   ],
   "entrypoints": [
-    "flit"
+    "flit-core"
   ],
   "enturclient": [
     "poetry-core"


### PR DESCRIPTION
Following from #558, entrypoints only requires flit-core to build.