### PR TITLE
pin dependencies of the update script

### DIFF
--- a/pkgs/poetry/nixpkgs.nix
+++ b/pkgs/poetry/nixpkgs.nix
@@ -1,0 +1,11 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ../../flake.lock);
+
+  lockedNixpkgs = lock.nodes.nixpkgs.locked;
+
+  tarball = (builtins.fetchTarball {
+    url = "https://github.com/${lockedNixpkgs.owner}/${lockedNixpkgs.repo}/archive/${lockedNixpkgs.rev}.tar.gz";
+    sha256 = lockedNixpkgs.narHash;
+  });
+in
+tarball

--- a/pkgs/poetry/update
+++ b/pkgs/poetry/update
@@ -1,11 +1,15 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p curl nix-prefetch-github jq
+#! nix-shell update-poetry-shell.nix -i bash
 
+set -x
 rev=$(curl -s https://api.github.com/repos/python-poetry/poetry/releases/latest | jq -r '.name')
+export NIX_PATH=nixpkgs=$(nix eval -f nixpkgs.nix --raw)
+# nix-prefetch-github requires 'nixpkgs' to be in NIX_PATH
 nix-prefetch-github --rev "$rev" python-poetry poetry > src.json
 echo >> src.json
 
-src=$(nix-build --no-out-link --expr 'with import <nixpkgs> {}; fetchFromGitHub (lib.importJSON ./src.json)')
-cp $src/pyproject.toml $src/poetry.lock .
+src=$(nix-build --no-out-link --expr 'with import (import ./nixpkgs.nix ) {}; fetchFromGitHub (lib.importJSON ./src.json)' --show-trace)
+echo "Printing source: $src"
+cp "$src/pyproject.toml" "$src/poetry.lock" .
 nix-shell -p poetry --run 'poetry lock'
-nix-build --expr '(import <nixpkgs> { overlays = [ (import ../../overlay.nix) ]; }).poetry'
+nix-build --expr '(import (import ./nixpkgs.nix) { overlays = [ (import ../../overlay.nix) ]; }).poetry' --show-trace

--- a/pkgs/poetry/update-poetry-shell.nix
+++ b/pkgs/poetry/update-poetry-shell.nix
@@ -1,0 +1,10 @@
+let
+  pkgs = import (import ./nixpkgs.nix) { };
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    curl
+    nix-prefetch-github
+    jq
+  ];
+}


### PR DESCRIPTION
right now the pkgs/poetry/update script looks for dependencies in the user <nixpkgs>.
I made it so that it sets NIX_PATH=nixpkgs=theOneFromTheFlake

My initial motivation was to bump poetry since I hit https://github.com/python-poetry/poetry/issues/4515
I haven't done it yet because I hit the following issue I am not sure how to address
```
poetry2nix/pkgs/poetry on  pin-nixpkgs via 🐍 took 26s 
➜ ./update
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels/nixos' does not exist, ignoring
error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)

       at «string»:1:9:

            1| (import <nixpkgs> {}).bashInteractive
             |         ^
will use bash from your environment
+ echo

++ curl -s https://api.github.com/repos/python-poetry/poetry/releases/latest
++ jq -r .name
+ rev=1.1.13
++ nix eval -f nixpkgs.nix --raw
+ export NIX_PATH=nixpkgs=/nix/store/fg5cspmfnm9qpi57lgbprspnjhj73y2a-source
+ NIX_PATH=nixpkgs=/nix/store/fg5cspmfnm9qpi57lgbprspnjhj73y2a-source
+ nix-prefetch-github --rev 1.1.13 python-poetry poetry
+ echo
++ nix-build --no-out-link --expr 'with import (import ./nixpkgs.nix ) {}; fetchFromGitHub (lib.importJSON ./src.json)' --show-trace
+ src=/nix/store/h7bc0m662rcbci6x107allj8wkkkwa15-source
+ echo 'Printing source'
Printing source
+ echo /nix/store/h7bc0m662rcbci6x107allj8wkkkwa15-source
/nix/store/h7bc0m662rcbci6x107allj8wkkkwa15-source
+ cp /nix/store/h7bc0m662rcbci6x107allj8wkkkwa15-source/pyproject.toml /nix/store/h7bc0m662rcbci6x107allj8wkkkwa15-source/poetry.lock .
+ nix-shell -p poetry --run 'poetry lock'
Updating dependencies
Resolving dependencies... (211.6s)

  SolverProblemError

  The current project's Python requirement (>=2.7,<2.8 || >=3.5,<4.0) is not compatible with some of the required packages Python requirement:
    - jeepney requires Python >=3.6, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6
    - jeepney requires Python >=3.5, so it will not be satisfied for Python >=2.7,<2.8
    - jeepney requires Python >=3.5, so it will not be satisfied for Python >=2.7,<2.8
    - keyring requires Python >=3.7, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.7
    - secretstorage requires Python >=3.5, so it will not be satisfied for Python >=2.7,<2.8
    - secretstorage requires Python >=3.6, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6
    - jeepney requires Python >=3.6, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6
    - jeepney requires Python >=3.6, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6
    - jeepney requires Python >=3.6, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6
  
      Because no versions of keyring match >21.2.0,<21.2.1 || >21.2.1,<21.3.0 || >21.3.0,<21.3.1 || >21.3.1,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<21.8.0 || >21.8.0,<22.0.0 || >22.0.0,<22.0.1 || >22.0.1,<22.1.0 || >22.1.0,<22.2.0 || >22.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0
   and keyring (21.2.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.2.1 || >21.2.1,<21.3.0 || >21.3.0,<21.3.1 || >21.3.1,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<21.8.0 || >21.8.0,<22.0.0 || >22.0.0,<22.0.1 || >22.0.1,<22.1.0 || >22.1.0,<22.2.0 || >22.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
      And because keyring (21.2.1) depends on jeepney (>=0.4.2)
   and keyring (21.3.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.3.1 || >21.3.1,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<21.8.0 || >21.8.0,<22.0.0 || >22.0.0,<22.0.1 || >22.0.1,<22.1.0 || >22.1.0,<22.2.0 || >22.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
      And because keyring (21.3.1) depends on jeepney (>=0.4.2)
   and keyring (22.2.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<21.8.0 || >21.8.0,<22.0.0 || >22.0.0,<22.0.1 || >22.0.1,<22.1.0 || >22.1.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
      And because keyring (22.1.0) depends on jeepney (>=0.4.2)
   and keyring (22.0.1) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<21.8.0 || >21.8.0,<22.0.0 || >22.0.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
      And because keyring (22.0.0) depends on jeepney (>=0.4.2)
   and keyring (21.8.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<21.6.0 || >21.6.0,<21.7.0 || >21.7.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
      And because keyring (21.7.0) depends on jeepney (>=0.4.2)
   and keyring (21.6.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<21.4.0 || >21.4.0,<21.5.0 || >21.5.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
  (1) So, because keyring (21.5.0) depends on jeepney (>=0.4.2)
   and keyring (21.4.0) depends on jeepney (>=0.4.2), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2).
  
      Because no versions of jeepney match >0.4.2,<0.4.3 || >0.4.3,<0.5.0 || >0.5.0,<0.6
   and jeepney (0.4.2) requires Python >=3.5, jeepney is forbidden.
      And because jeepney (0.4.3) requires Python >=3.5
   and jeepney (0.5.0) requires Python >=3.6, jeepney is forbidden.
      And because keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.4.2) (1), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1,<23.5.0 || >23.5.0) requires jeepney (>=0.6)
      And because keyring (23.5.0) requires Python >=3.7, keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0,<23.4.0 || >23.4.0,<23.4.1 || >23.4.1) requires jeepney (>=0.6).
      And because keyring (23.4.1) depends on SecretStorage (>=3.2)
   and keyring (23.4.0) depends on SecretStorage (>=3.2), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0,<23.2.1 || >23.2.1,<23.3.0 || >23.3.0) requires jeepney (>=0.6) or SecretStorage (>=3.2).
      And because keyring (23.3.0) depends on SecretStorage (>=3.2)
   and keyring (23.2.1) depends on SecretStorage (>=3.2), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1,<23.1.0 || >23.1.0,<23.2.0 || >23.2.0) requires jeepney (>=0.6) or SecretStorage (>=3.2).
      And because keyring (23.2.0) depends on SecretStorage (>=3.2)
   and keyring (23.1.0) depends on SecretStorage (>=3.2), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0,<23.0.0 || >23.0.0,<23.0.1 || >23.0.1) requires jeepney (>=0.6) or SecretStorage (>=3.2).
      And because keyring (23.0.1) depends on SecretStorage (>=3.2)
   and keyring (23.0.0) depends on SecretStorage (>=3.2), keyring (>=21.2.0,<22.3.0 || >22.3.0,<22.4.0 || >22.4.0) requires jeepney (>=0.6) or SecretStorage (>=3.2).
  (2) So, because keyring (22.4.0) depends on SecretStorage (>=3.2)
   and keyring (22.3.0) depends on SecretStorage (>=3.2), keyring (>=21.2.0) requires jeepney (>=0.6) or SecretStorage (>=3.2).
  
      Because no versions of secretstorage match >3.2,<3.3.0 || >3.3.0,<3.3.1 || >3.3.1
   and secretstorage (3.2.0) requires Python >=3.5, secretstorage is forbidden.
      And because secretstorage (3.3.0) requires Python >=3.6, secretstorage is forbidden.
      And because keyring (>=21.2.0) requires jeepney (>=0.6) or SecretStorage (>=3.2) (2), keyring (>=21.2.0) requires jeepney (>=0.6) or secretstorage (3.3.1)
  (3) So, because secretstorage (3.3.1) depends on jeepney (>=0.6), keyring (>=21.2.0) requires jeepney (>=0.6).
  
      Because no versions of jeepney match >0.6,<0.7.0 || >0.7.0,<0.7.1 || >0.7.1
   and jeepney (0.6.0) requires Python >=3.6, jeepney is forbidden.
      And because jeepney (0.7.0) requires Python >=3.6
   and jeepney (0.7.1) requires Python >=3.6, jeepney is forbidden.
      And because keyring (>=21.2.0) requires jeepney (>=0.6) (3), keyring is forbidden
      So, because poetry depends on keyring (>=21.2.0), version solving failed.

  at /nix/store/4xvn48w3a2hqxgbyis42iajs5hyy5s3p-python3.8-poetry-1.1.4/lib/python3.8/site-packages/poetry/puzzle/solver.py:241 in _solve
      237│             packages = result.packages
      238│         except OverrideNeeded as e:
      239│             return self.solve_in_compatibility_mode(e.overrides, use_latest=use_latest)
      240│         except SolveFailure as e:
    → 241│             raise SolverProblemError(e)
      242│ 
      243│         results = dict(
      244│             depth_first_search(
      245│                 PackageNode(self._package, packages), aggregate_package_nodes

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
    
    For jeepney, a possible solution would be to set the `python` property to ">=3.6,<4.0"
    For jeepney, a possible solution would be to set the `python` property to ">=3.5,<4.0"
    For jeepney, a possible solution would be to set the `python` property to ">=3.5,<4.0"
    For keyring, a possible solution would be to set the `python` property to ">=3.7,<4.0"
    For secretstorage, a possible solution would be to set the `python` property to ">=3.5,<4.0"
    For secretstorage, a possible solution would be to set the `python` property to ">=3.6,<4.0"
    For jeepney, a possible solution would be to set the `python` property to ">=3.6,<4.0"
    For jeepney, a possible solution would be to set the `python` property to ">=3.6,<4.0"
    For jeepney, a possible solution would be to set the `python` property to ">=3.6,<4.0"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```
