### PR TITLE
chore(build-systems/mkdocs-autorefs): add pdm-pep517 to nativeBuildInputs

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -557,7 +557,8 @@
     "poetry-core"
   ],
   "mkdocs-autorefs": [
-    "poetry"
+    "poetry",
+    "pdm-pep517"
   ],
   "mkdocs-gen-files": [
     "poetry"


### PR DESCRIPTION
It looks like `mkdocs-autorefs` moved from `poetry` to `pdm` recently.

I'm not sure if including both `poetry` and `pdm-pep517` in `nativeBuildInputs`
is a great idea, but I'm also not sure how to handle build systems that differ
by version.

@adisbladis is there a way to do that in `poetry2nix` currently?
