### PR TITLE
chore(build-systems): add pytest-profiling

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -917,6 +917,9 @@
   "pytest-mockservers": [
     "poetry-core"
   ],
+  "pytest-profiling": [
+    "setuptools-git"
+  ],
   "pytest-raisin": [
     "flit-core",
     "flitBuildHook"


### PR DESCRIPTION
- chore(build-systems/mkdocs-autorefs): add pdm-pep517 to nativeBuildInputs
- build-systems: add pytest-profiling
