### PR TITLE
overrides.ccxt: patch path to README

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -188,6 +188,12 @@ lib.composeManyExtensions [
               '';
             }) else drv;
 
+      ccxt = super.ccxt.overridePythonAttrs (old: {
+        preBuild = ''
+          ln -s README.{rst,md}
+        '';
+      });
+
       celery = super.celery.overridePythonAttrs (old: {
         propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.setuptools ];
       });


### PR DESCRIPTION
MarkDown file doesn't exist in source, yet is sourced, so let's place it
there.