### PR TITLE
fix: avoid infinite recursion while searching for path

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -180,7 +180,7 @@ let
       hasGitIgnore = builtins.pathExists gitIgnore;
       gitIgnores = if hasGitIgnore then [ gitIgnore ] else [ ];
     in
-    lib.optionals (builtins.toString path != "/" && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
+    lib.optionals (builtins.pathExists path && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
 
   /*
     Provides a source filtering mechanism that:


### PR DESCRIPTION
In `findGitIgnores`, to find the parent path, we do `path + "/.."`. This means that, for each iteration, the path name grows:

1. `/nix/store/1234-example/a/b/`
2. `/nix/store/1234-example/a/b/..`
3. `/nix/store/1234-example/a/b/../..`
4. etc.

Thus, checking if path is not equal to `/` will always return `true`.

With this fix, it will instead check that the path exists. If the path goes higher than `/`, it will not exist, thus fixing the false positive.

Fixes the failure exercised in https://gitlab.com/moduon/mrchef/-/merge_requests/1.

You can reproduce it with:

    nix flake check 'gitlab:moduon/mrchef?rev=7f6177504daaa74d1b8dc64b256fbf15866efb3a' --show-trace

[The next commit includes the fix](https://gitlab.com/moduon/mrchef/-/commit/6466f3e360d1e44f40dea04e376ec48745700007#58cb4f58166586c1ed7f076c568d41682df3661c) and won't fail:

    nix flake check 'gitlab:moduon/mrchef?rev=6466f3e360d1e44f40dea04e376ec48745700007' --show-trace

@moduon MT-83