### PR TITLE
fix: support nullified editablePackageSources in mkPoetryEnv

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -287,11 +287,19 @@ lib.makeScope pkgs.newScope (self: {
         (name: value: projectDir + "/${value.path}")
         (lib.filterAttrs (name: dep: dep.develop or false && hasAttr "path" dep) set);
 
-      editablePackageSources' = (
+      excludedEditablePackageNames = builtins.filter
+        (pkg: editablePackageSources."${pkg}" == null)
+        (builtins.attrNames editablePackageSources);
+
+      allEditablePackageSources = (
         (getEditableDeps (pyProject.tool.poetry."dependencies" or { }))
         // (getEditableDeps (pyProject.tool.poetry."dev-dependencies" or { }))
         // editablePackageSources
       );
+
+      editablePackageSources' = builtins.removeAttrs
+        allEditablePackageSources
+        excludedEditablePackageNames;
 
       poetryPython = self.mkPoetryPackages {
         inherit pyproject poetrylock overrides python pwd preferWheels pyProject;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -43,6 +43,7 @@ builtins.removeAttrs
   in-list = callTest ./in-list { };
   cli = poetry2nix;
   path-deps = callTest ./path-deps { };
+  path-deps-develop = callTest ./path-deps-develop { };
   path-deps-level2 = callTest ./path-deps-level2 { };
   operators = callTest ./operators { };
   preferWheel = callTest ./prefer-wheel { };

--- a/tests/path-deps-develop/default.nix
+++ b/tests/path-deps-develop/default.nix
@@ -1,0 +1,21 @@
+{ lib, poetry2nix, python3, runCommand }:
+
+let env = poetry2nix.mkPoetryEnv {
+  python = python3;
+  projectDir = ./.;
+  editablePackageSources = {
+    dep1 = null;
+  };
+};
+
+in
+lib.debug.runTests {
+  testDepFound = {
+    expected = "0\n";
+    expr = builtins.readFile (runCommand "path-deps-develop-import" { } ''
+      echo using ${env}
+      ${env}/bin/python -c 'import dep1'
+      echo $? > $out
+    '');
+  };
+}

--- a/tests/path-deps-develop/dep1/setup.py
+++ b/tests/path-deps-develop/dep1/setup.py
@@ -1,0 +1,6 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="dep1",
+    packages=find_packages(),
+)

--- a/tests/path-deps-develop/poetry.lock
+++ b/tests/path-deps-develop/poetry.lock
@@ -1,0 +1,20 @@
+[[package]]
+name = "dep1"
+version = "0.0.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = true
+
+[package.source]
+type = "directory"
+url = "dep1"
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.6"
+content-hash = "fda111f4898026d22d40f4d601bf3782b8ef7795da41cb780d59894a4732f8bc"
+
+[metadata.files]
+dep1 = []

--- a/tests/path-deps-develop/pyproject.toml
+++ b/tests/path-deps-develop/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "path_deps_develop"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.6"
+dep1 = {path = "dep1", develop = true}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
See these docs: https://github.com/nix-community/poetry2nix/blob/99c79568352799af09edaeefc858d337e6d9c56f/README.md?plain=1#L86

They say that any dependency passed as `null` is forced to be non editable, even if it is marked as `develop = true` in `pyproject.toml`.

However, this was not being the case.

Added a test to prove the need for the fix.

@moduon MT-83