### PR TITLE
fix: avoid infinite recursion while searching for path #585

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -180,7 +180,7 @@ let
       hasGitIgnore = builtins.pathExists gitIgnore;
       gitIgnores = if hasGitIgnore then [ gitIgnore ] else [ ];
     in
-    lib.optionals (builtins.toString path != "/" && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
+    lib.optionals (builtins.pathExists path && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
 
   /*
     Provides a source filtering mechanism that:

--- a/lib.nix
+++ b/lib.nix
@@ -180,7 +180,7 @@ let
       hasGitIgnore = builtins.pathExists gitIgnore;
       gitIgnores = if hasGitIgnore then [ gitIgnore ] else [ ];
     in
-    lib.optionals (builtins.pathExists path && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
+    lib.optionals (builtins.pathExists path && builtins.toString path != "/" && ! isGitRoot) (findGitIgnores parent) ++ gitIgnores;
 
   /*
     Provides a source filtering mechanism that:


### PR DESCRIPTION
Since I'm not allowed to force push #585 I'm opening this PR for a CI run before merge.

Closes #585 