### PR TITLE
make soundfile find libsndfile at runtime

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1895,6 +1895,12 @@ lib.composeManyExtensions [
 
       });
 
+      soundfile = super.soundfile.overridePythonAttrs(old: {
+        postPatch = ''
+          substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${pkgs.libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
+        '';
+      });
+
       systemd-python = super.systemd-python.overridePythonAttrs (old: {
         buildInputs = old.buildInputs ++ [ pkgs.systemd ];
         nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkg-config ];

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1895,7 +1895,7 @@ lib.composeManyExtensions [
 
       });
 
-      soundfile = super.soundfile.overridePythonAttrs(old: {
+      soundfile = super.soundfile.overridePythonAttrs (old: {
         postPatch = ''
           substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${pkgs.libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
         '';


### PR DESCRIPTION
See #594

This solved my issue locally.  I'm not sure how to check for this in `tests/`, Since it's a runtime error not picked up at `mkPoetryApplication`.

`postPatch` phase is chosen only because that's what's in NixPkgs.

Thanks to @takeda for their guidance!