### PR TITLE
overrides.psycopg2cffi: Add override

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1303,6 +1303,14 @@ lib.composeManyExtensions [
         }
       );
 
+      psycopg2cffi = super.psycopg2cffi.overridePythonAttrs (
+        old: {
+          buildInputs = (old.buildInputs or [ ])
+            ++ lib.optional stdenv.isDarwin pkgs.openssl;
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.postgresql ];
+        }
+      );
+
       py-solc-x = super.py-solc-x.overridePythonAttrs (
         old: {
           preConfigure = ''


### PR DESCRIPTION
With this I can build Synapse `v1.58.0` which has just migrated to Poetry: https://matrix.org/blog/2022/05/05/synapse-1-58-released.