### PR TITLE
Fix pytest-6.2.5

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1690,7 +1690,10 @@ lib.composeManyExtensions [
         old: {
           # Fixes https://github.com/pytest-dev/pytest/issues/7891
           postPatch = old.postPatch or "" + ''
-            sed -i '/\[metadata\]/aversion = ${old.version}' setup.cfg
+            # sometimes setup.cfg doesn't exist
+            if [ -f setup.cfg ]; then
+              sed -i '/\[metadata\]/aversion = ${old.version}' setup.cfg
+            fi
           '';
         }
       );


### PR DESCRIPTION
At least in `pytest-6.2.5`, `setup.cfg` doesn't exist. 
Added a check to make sure it exists before attempting to update it

Before change, i get:
```
error: builder for '/nix/store/cjyjz8m6437fb5k1m0d0555mx62scka1-python3.9-pytest-6.2.5.drv' failed with exit code 2;
       ...
       > sed: can't read setup.cfg: No such file or directory
       For full logs, run 'nix log /nix/store/cjyjz8m6437fb5k1m0d0555mx62scka1-python3.9-pytest-6.2.5.drv'.
```

After change, `pytest` builds successfully.
