### PR TITLE
overrides.file-magic: patch it to find libmagic

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -518,6 +518,14 @@ lib.composeManyExtensions [
         }
       );
 
+      file-magic = super.file-magic.overridePythonAttrs (
+        old: {
+          postPatch = ''
+            substituteInPlace magic.py --replace "find_library('magic')" "'${pkgs.file}/lib/libmagic${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}'"
+          '';
+        }
+      );
+
       fiona = super.fiona.overridePythonAttrs (
         old: {
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.gdal_2 ];


### PR DESCRIPTION
The patch is adapted from nixpkgs:

  https://github.com/NixOS/nixpkgs/blob/77aff919e15c8e2e9a335bf7028720750d0381fd/pkgs/development/python-modules/magic/default.nix#L12