### PR TITLE
Use flit-core as build system for pyparsing after 3.0.8

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1555,6 +1555,15 @@ lib.composeManyExtensions [
         }
       );
 
+      pyparsing =
+        if (lib.versionAtLeast super.pyparsing.version "3.0.8") then
+          addBuildSystem
+            {
+              inherit self;
+              drv = super.pyparsing;
+              attr = "flit-core";
+            } else super.pyparsing;
+
       pyproj = super.pyproj.overridePythonAttrs (
         old: {
           PROJ_DIR = "${pkgs.proj}";


### PR DESCRIPTION
The project switched to flit. See the [Release Notes for pyparsing](https://github.com/pyparsing/pyparsing/releases).