### PR TITLE
Updated patch for mypy 0.960+

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1112,8 +1112,8 @@ lib.composeManyExtensions [
             })
           ] ++ lib.optionals (lib.strings.versionAtLeast old.version "0.960") [
             (pkgs.fetchpatch {
-              url = "https://github.com/python/mypy/compare/a6166b2f..5b3c9888.patch";
-              sha256 = "sha256-3QY99ctkIv9PoNfcTKF9TZFBwAIVOqPLKBVP6rDQ9FU=";
+              url = "https://github.com/python/mypy/commit/2004ae023b9d3628d9f09886cbbc20868aee8554.patch";
+              sha256 = "sha256-y+tXvgyiECO5+66YLvaje8Bz5iPvfWNIBJcsnZ2nOdI=";
             })
           ];
         }


### PR DESCRIPTION
The old patch URL did not apply cleanly for 0.960 and 0.961.

Looks like the PR was eventually merged so hopefully these might be the last versions needing a patch.

Fixes https://github.com/nix-community/poetry2nix/issues/656