### PR TITLE
overrides.secp256k1: Loosen up pytest-runner version constraint

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1898,7 +1898,8 @@ lib.composeManyExtensions [
         # Local setuptools versions like "x.y.post0" confuse an internal check
         postPatch = ''
           substituteInPlace setup.py \
-            --replace 'setuptools_version.' '"${self.setuptools.version}".'
+            --replace 'setuptools_version.' '"${self.setuptools.version}".' \
+            --replace 'pytest-runner==' 'pytest-runner>='
         '';
       });
 


### PR DESCRIPTION
It's curerntly set to a specific version in setup.py, but since it's missing from
dependency metadata it fails at build time.