### PR TITLE
build-systems: add hatchling to traitlets

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1690,7 +1690,8 @@
     "pbr"
   ],
   "traitlets": [
-    "flit-core"
+    "flit-core",
+    "hatchling"
   ],
   "transmission-rpc": [
     "poetry-core"


### PR DESCRIPTION
traitlets switched to the hatchling backend starting with [version 5.2.1](https://github.com/ipython/traitlets/releases/tag/5.2.1).