### PR TITLE
build-systems: optional build system objects with version information

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -591,6 +591,9 @@
   "json-schema-for-humans": [
     "poetry-core"
   ],
+  "jsonschema": [
+    "hatchling"
+  ],
   "jupyter-server": [
     "jupyter-packaging"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -592,7 +592,7 @@
     "poetry-core"
   ],
   "jsonschema": [
-    "hatchling"
+    { "buildSystem": "hatchling", "from": "4.6.0" }
   ],
   "jupyter-server": [
     "jupyter-packaging"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1693,7 +1693,8 @@
     "pbr"
   ],
   "traitlets": [
-    "flit-core"
+    { "buildSystem": "flit-core", "until": "5.2.1" },
+    { "buildSystem": "hatchling", "from": "5.2.1" }
   ],
   "transmission-rpc": [
     "poetry-core"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -24,6 +24,11 @@ let
                 self.${attr.buildSystem}
             else
               null
+          else if builtins.hasAttr "until" attr then
+            if lib.versionOlder drv.version attr.until then
+              self.${attr.buildSystem}
+            else
+              null
           else
             self.${attr.buildSystem}
         else


### PR DESCRIPTION
jsonschema switched to the hatchling backend starting with [version 4.6.0](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.6.0).