### PR TITLE
build-systems: add sane-python

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1421,6 +1421,9 @@
   "rtmixer": [
     "cython"
   ],
+  "sane-python": [
+    "poetry-core"
+  ],
   "sanic": [
     "poetry-core"
   ],


### PR DESCRIPTION
`sane-python` uses `poetry-core` as the build-system.