### PR TITLE
build-systems: add hatch-vcs for jsonschema >= 4.6.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -595,7 +595,7 @@
     "poetry-core"
   ],
   "jsonschema": [
-    { "buildSystem": "hatchling", "from": "4.6.0" }
+    { "buildSystem": "hatch-vcs", "from": "4.6.0" }
   ],
   "jupyter-server": [
     "jupyter-packaging"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -595,6 +595,7 @@
     "poetry-core"
   ],
   "jsonschema": [
+    { "buildSystem": "hatchling", "from": "4.6.0" },
     { "buildSystem": "hatch-vcs", "from": "4.6.0" }
   ],
   "jupyter-server": [


### PR DESCRIPTION
After #663 `jsonschema` still did not build for me:
```
Processing /build/jsonschema-4.6.0
  Running command Preparing metadata (pyproject.toml)
  Traceback (most recent call last):
    File "/nix/store/gq3ws3843pr18gsfafnmc6n2wv5a85sv-python3.9-pip-22.0.4/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 156, in prepare_metadata_for_build_wheel
      hook = backend.prepare_metadata_for_build_wheel
  AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_wheel'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 1197, in cached
      self._cached = self.source.get_version_data()['version']
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 1245, in source
      raise UnknownPluginError('Unknown version source: {}'.format(source_name))
  hatchling.plugin.exceptions.UnknownPluginError: Unknown version source: vcs

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/nix/store/gq3ws3843pr18gsfafnmc6n2wv5a85sv-python3.9-pip-22.0.4/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/nix/store/gq3ws3843pr18gsfafnmc6n2wv5a85sv-python3.9-pip-22.0.4/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/nix/store/gq3ws3843pr18gsfafnmc6n2wv5a85sv-python3.9-pip-22.0.4/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 160, in prepare_metadata_for_build_wheel
      whl_basename = backend.build_wheel(metadata_directory, config_settings)
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/build.py", line 41, in build_wheel
      return os.path.basename(next(builder.build(wheel_directory, ['standard'])))
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 146, in build
      artifact = version_api[version](directory, **build_data)
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/builders/wheel.py", line 322, in build_standard
      with WheelArchive(self.project_id, self.config.reproducible) as archive, closing(StringIO()) as records:
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 347, in project_id
      self.metadata.version,
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 64, in version
      self._set_version()
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 157, in _set_version
      version = self.hatch.version.cached
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 1200, in cached
      'Error getting the version from source `{}`: {}'.format(self.source.PLUGIN_NAME, e)
    File "/nix/store/h2lp7lnbrqx0zb5qk2krh62g5v9ifa8d-python3.9-hatchling-0.25.0/lib/python3.9/site-packages/hatchling/metadata/core.py", line 1245, in source
      raise UnknownPluginError('Unknown version source: {}'.format(source_name))
  hatchling.plugin.exceptions.UnknownPluginError: Unknown version source: vcs
```
Apparently just adding the `hatchling` module is not enough, and the `hatch-vcs` plugin is also required for a successful build.

The suggested change relies on the `hatch-vcs` module dependencies also including the main `hatchling` module; if you prefer, it should also be possible to add both modules explicitly:
```json
  "jsonschema": [
    { "buildSystem": "hatchling", "from": "4.6.0" },
    { "buildSystem": "hatch-vcs", "from": "4.6.0" }
  ],
```
(Or, if you also don't like the duplicate condition in that case, some more refactoring of `addBuildSystem` would be needed to add support for setting `extraAttrs` from JSON.)