### PR TITLE
fix: also ignore typing-extensions when resolving dependencies

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -98,6 +98,7 @@ pythonPackages.callPackage
         "packaging"
         "six"
         "pyparsing"
+        "typing-extensions"
       ];
       baseBuildInputs = lib.optional (! lib.elem name skipSetupToolsSCM) pythonPackages.setuptools-scm;
       format = if isDirectory || isGit || isUrl then "pyproject" else fileInfo.format;


### PR DESCRIPTION
Fixes infinite recursion with recent setuptools-scm.

CC #648 (but not a proper fix)