### PR TITLE
Cryptography 37.0.4

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -325,6 +325,7 @@ lib.composeManyExtensions [
             "36.0.1" = "sha256-kozYXkqt1Wpqyo9GYCwN08J+zV92ZWFJY/f+rulxmeQ=";
             "36.0.2" = "1a0ni1a3dbv2dvh6gx2i54z8v5j9m6asqg97kkv7gqb1ivihsbp8";
             "37.0.2" = "sha256-qvrxvneoBXjP96AnUPyrtfmCnZo+IriHR5HbtWQ5Gk8=";
+            "37.0.4" = "sha256-f8r6QclTwkgK20CNe9i65ZOqvSUeDc4Emv6BFBhh1hI";
           }.${version} or null;
           sha256 = getCargoHash super.cryptography.version;
           scrypto =

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -326,7 +326,9 @@ lib.composeManyExtensions [
             "36.0.2" = "1a0ni1a3dbv2dvh6gx2i54z8v5j9m6asqg97kkv7gqb1ivihsbp8";
             "37.0.2" = "sha256-qvrxvneoBXjP96AnUPyrtfmCnZo+IriHR5HbtWQ5Gk8=";
             "37.0.4" = "sha256-f8r6QclTwkgK20CNe9i65ZOqvSUeDc4Emv6BFBhh1hI";
-          }.${version} or null;
+          }.${version} or (
+            lib.warn "Unknown cryptography version: '${version}'. Please update getCargoHash." lib.fakeHash
+          );
           sha256 = getCargoHash super.cryptography.version;
           scrypto =
             if lib.versionAtLeast super.cryptography.version "35" && sha256 == null then

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -325,7 +325,6 @@ lib.composeManyExtensions [
             "36.0.1" = "sha256-kozYXkqt1Wpqyo9GYCwN08J+zV92ZWFJY/f+rulxmeQ=";
             "36.0.2" = "1a0ni1a3dbv2dvh6gx2i54z8v5j9m6asqg97kkv7gqb1ivihsbp8";
             "37.0.2" = "sha256-qvrxvneoBXjP96AnUPyrtfmCnZo+IriHR5HbtWQ5Gk8=";
-            "37.0.3" = "sha256-Wz3cyyOT+J09a98xyh2N1pxpANdY1u3Z9PboIEwwaIc";
           }.${version} or null;
           sha256 = getCargoHash super.cryptography.version;
           scrypto =


### PR DESCRIPTION
See https://github.com/nix-community/poetry2nix/pull/679#issuecomment-1175235244 for why I have removed 37.0.4
Also see https://github.com/openssl/openssl/commit/6677e4519d09ce49e83217fa1f685e592d1648f3 for the actual regression that actually brings down the whole application when ran an a sufficiently new CPU.

Also improved the error message for unknown versions to make updating cryptography easier in the future.
