### PR TITLE
cfel-pylint-checkers: add poetry-core to build-systems.json

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -195,6 +195,9 @@
   "censys": [
     "poetry-core"
   ],
+  "cfel-pylint-checkers": [
+    "poetry-core"
+  ],
   "cftime": [
     "cython"
   ],


### PR DESCRIPTION
`cfel-pylint-checkers` is a package I maintain, so if there are any questions, I can change things.