### PR TITLE
Fix build failure when pyproject.toml contains editable path dependencies

### DIFF
--- a/hooks/pyproject-without-special-deps.py
+++ b/hooks/pyproject-without-special-deps.py
@@ -22,6 +22,7 @@ def main(input, output, fields_to_remove):
                     any_removed |= dep.pop(field, None) is not None
                 if any_removed:
                     dep["version"] = "*"
+                    dep.pop("develop", None)
 
     output.write(tomlkit.dumps(data))
 

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1351,13 +1351,18 @@ lib.composeManyExtensions [
       );
 
       pillow = super.pillow.overridePythonAttrs (
-        old: {
+        old:
+        let
+          preConfigure = (old.preConfigure or "") + pkgs.python3.pkgs.pillow.preConfigure;
+        in
+        {
           nativeBuildInputs = (old.nativeBuildInputs or [ ])
             ++ [ pkg-config self.pytest-runner ];
           buildInputs = with pkgs; (old.buildInputs or [ ])
             ++ [ freetype libjpeg zlib libtiff libwebp tcl lcms2 ]
             ++ lib.optionals (lib.versionAtLeast old.version "7.1.0") [ xorg.libxcb ]
             ++ lib.optionals (self.isPyPy) [ tk xorg.libX11 ];
+          preConfigure = lib.optional (old.format != "wheel") preConfigure;
         }
       );
 


### PR DESCRIPTION
`mkPoetryApplication` fails when a editable path dependency exists in `pyproject.toml`, similar to #284 

This PR fix the problem by removing `develop` attributes in path / git dependencies in hooks.