### PR TITLE
build-systems: use pdm-pep517 for griffe

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -474,6 +474,9 @@
   "gridnet": [
     "poetry-core"
   ],
+  "griffe": [
+    "pdm-pep517"
+  ],
   "grpcio": [
     "cython"
   ],


### PR DESCRIPTION
[griffe](https://github.com/mkdocstrings/griffe) uses pdm-pep517 for build system.