### PR TITLE
build-systems: use hatchling for jupyterlab-server

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -622,6 +622,9 @@
   "jupyterlab-pygments": [
     "jupyter-packaging"
   ],
+  "jupyterlab-server": [
+    "hatchling"
+  ],
   "keystoneauth1": [
     "pbr"
   ],


### PR DESCRIPTION
jupyterlab-server requires hatchling for build system.