### PR TITLE
build-systems: use flit-core for pkgutil-resolve-name

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -962,6 +962,9 @@
   "pkgconfig": [
     "poetry-core"
   ],
+  "pkgutil-resolve-name": [
+    "flit-core"
+  ],
   "plux": [
     "pytest-runner"
   ],


### PR DESCRIPTION
[`pkgutil-resolve-name`](https://github.com/graingert/pkgutil-resolve-name) uses `flit-core` for build system.