### PR TITLE
build-systems(jupyter-server-mathjax, jupyterlab-git): use jupyter-packaging

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -619,10 +619,16 @@
   "jupyter-server": [
     "jupyter-packaging"
   ],
+  "jupyter-server-mathjax": [
+    "jupyter-packaging"
+  ],
   "jupyterlab": [
     "jupyter-packaging"
   ],
   "jupyterlab-code-formatter": [
+    "jupyter-packaging"
+  ],
+  "jupyterlab-git": [
     "jupyter-packaging"
   ],
   "jupyterlab-pygments": [


### PR DESCRIPTION
These two jupyter server/lab extensions require `jupyter-packaging` for build.

- [jupyter_server_mathjax][1]
- [jupyterlab-git][2]

[1]: https://github.com/jupyter-server/jupyter_server_mathjax
[2]: https://github.com/jupyterlab/jupyterlab-git