### PR TITLE
build-systems: use hatch-fancy-pypi-readme for jsonschema >= 4.11.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -608,7 +608,8 @@
   ],
   "jsonschema": [
     { "buildSystem": "hatchling", "from": "4.6.0" },
-    { "buildSystem": "hatch-vcs", "from": "4.6.0" }
+    { "buildSystem": "hatch-vcs", "from": "4.6.0" },
+    { "buildSystem": "hatch-fancy-pypi-readme", "from": "4.11.0" }
   ],
   "jupyter-client": [
     "hatchling"


### PR DESCRIPTION
The `jsonschema` module got yet another build dependency in the 4.11.0 release — `hatch-fancy-pypi-readme`:
https://github.com/python-jsonschema/jsonschema/pull/983/commits/a9b5bb2a7cd02bee23b0d2ea33cdf395854de4df