### PR TITLE
build-systems: use poetry-core for dotty-dict >= 1.3.1

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -318,6 +318,9 @@
   "docstring-parser": [
     "poetry-core"
   ],
+  "dotty-dict": [
+    { "buildSystem": "poetry-core", "from": "1.3.1" }
+  ],
   "dtlssocket": [
     "cython"
   ],


### PR DESCRIPTION
The `dotty-dict` module switched to the `poetry-core` build system since release 1.3.1:
https://github.com/pawelzny/dotty_dict/commit/a3f4b3f52d3bbad56aeccb0f4bd2c4bab14d451a#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711
(`pyproject.toml` in that commit still says “1.3.0”, but that's actually a post-1.3.0 commit)