### PR TITLE
fix poetry replacing underscores with hyphens

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ let
   # Poetry2nix version
   version = "1.31.0";
 
-  inherit (poetryLib) isCompatible readTOML moduleName;
+  inherit (poetryLib) isCompatible readTOML moduleName underscorify;
 
   # Map SPDX identifiers to license names
   spdxLicenses = lib.listToAttrs (lib.filter (pair: pair.name != null) (builtins.map (v: { name = if lib.hasAttr "spdxId" v then v.spdxId else null; value = v; }) (lib.attrValues lib.licenses)));
@@ -182,7 +182,7 @@ lib.makeScope pkgs.newScope (self: {
                       source = pkgMeta.source or null;
                       files = lockFiles.${name};
                       pythonPackages = self;
-                      sourceSpec = pyProject.tool.poetry.dependencies.${name} or pyProject.tool.poetry.dev-dependencies.${name} or { };
+                      sourceSpec = pyProject.tool.poetry.dependencies.${underscorify pkgMeta.name} or pyProject.tool.poetry.dev-dependencies.${underscorify pkgMeta.name} or { };
                     }
                   );
                 }

--- a/lib.nix
+++ b/lib.nix
@@ -11,6 +11,10 @@ let
   # Do some canonicalisation of module names
   moduleName = name: lib.toLower (lib.replaceStrings [ "_" "." ] [ "-" "-" ] name);
 
+  # For some reason, poetry replaces underscores with dashes in module
+  # names, this has to be reversed sometimes
+  underscorify = name: (lib.replaceStrings [ "-" ] [ "_" ] name);
+
   # Get a full semver pythonVersion from a python derivation
   getPythonVersion = python:
     let
@@ -234,6 +238,7 @@ in
     satisfiesSemver
     cleanPythonSources
     moduleName
+    underscorify
     getPythonVersion
     getTargetMachine
     ;


### PR DESCRIPTION
Poetry replaces underscores with hyphens in module names.

This leads to the problem that things like
```

[tool.poetry.dependencies]
hiro_models = { git = "git@github.com:vale981/two_qubit_model.git", branch="online_calculation" }
```
don't work, because the `sourceSpec` is empty in

```
if isGit then
          (
            builtins.fetchGit ({
              inherit (source) url;
              rev = source.resolved_reference or source.reference;
              ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
            } // (
              let
                nixVersion = builtins.substring 0 3 builtins.nixVersion;
              in
              lib.optionalAttrs ((sourceSpec ? rev) && (lib.versionAtLeast nixVersion "2.4")) {
                allRefs = true;
              }
            ))
          )
```

The poetry lock entry for this looks like
```
[[package]]
name = "hiro-models"
version = "1.2.3"
description = "Operators for a general model of two interacting qubits coupled to two baths."
category = "main"
optional = false
python-versions = ">=3.9,<3.11"
develop = false
```


