### PR TITLE
site-packages fixup hook: Also remove LICENSE files

### DIFF
--- a/hooks/default.nix
+++ b/hooks/default.nix
@@ -70,6 +70,7 @@ in
             filenames = builtins.concatStringsSep " " [
               "pyproject.toml"
               "README.md"
+              "LICENSE"
             ];
           };
         } ./fixup-hook.sh


### PR DESCRIPTION
Prevents:
```
python3> error: collision between `/nix/store/l2ys5d4p144krknjy4iismcyppgfnwq8-python3.9-rsa-4.8/lib/python3.9/site-packages/LICENSE' and `/nix/store/lym0ljzxd0wc7m6m6pvpc4i6yv4jrig2-python3.9-types-s3transfer-0.6.0.post4/lib/python3.9/site-packages/LICENSE'
error: builder for '/nix/store/k99pmcqj8c5sbrpgi2kx0x7zv3cisgwf-python3-3.9.13-env.drv' failed with exit code 25;
       last 1 log lines:
       > error: collision between `/nix/store/l2ys5d4p144krknjy4iismcyppgfnwq8-python3.9-rsa-4.8/lib/python3.9/site-packages/LICENSE' and `/nix/store/lym0ljzxd0wc7m6m6pvpc4i6yv4jrig2-python3.9-types-s3transfer-0.6.0.post4/lib/python3.9/site-packages/LICENSE'
       For full logs, run 'nix log /nix/store/k99pmcqj8c5sbrpgi2kx0x7zv3cisgwf-python3-3.9.13-env.drv'.
error: 1 dependencies of derivation '/nix/store/i1y33k1jc5w467z7nsrynd4zp6rq3g3h-interactive-python3-3.9.13-environment.drv' failed to build
```

Reported privately by @matthewcroughan.