### PR TITLE
Fix determining sourceSpec for git dependencies in pyproject.toml

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -182,7 +182,15 @@ lib.makeScope pkgs.newScope (self: {
                       source = pkgMeta.source or null;
                       files = lockFiles.${name};
                       pythonPackages = self;
-                      sourceSpec = pyProject.tool.poetry.dependencies.${underscorify pkgMeta.name} or pyProject.tool.poetry.dev-dependencies.${underscorify pkgMeta.name} or { };
+                      # Packages can be specified with underscores in pyproject.toml; check for
+                      # both possibilities.
+                      sourceSpec = with pyProject.tool.poetry; (
+                        dependencies.${pkgMeta.name} or
+                          dependencies.${underscorify pkgMeta.name} or
+                            dev-dependencies.${pkgMeta.name} or
+                              dev-dependencies.${underscorify pkgMeta.name} or
+                                { }
+                      );
                     }
                   );
                 }

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -172,10 +172,7 @@ pythonPackages.callPackage
               rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             } // (
-              let
-                nixVersion = builtins.substring 0 3 builtins.nixVersion;
-              in
-              lib.optionalAttrs ((sourceSpec ? rev) && (lib.versionAtLeast nixVersion "2.4")) {
+              lib.optionalAttrs ((sourceSpec ? rev) && (lib.versionAtLeast builtins.nixVersion "2.4")) {
                 allRefs = true;
               }
             ))


### PR DESCRIPTION
#702 introduces a regression where dependencies that specify git repositories don't load correctly. This PR changes the lookup to use both the standard name (with hyphens) and the one with underscores (so that the use case in #702 continues to work).

This also addresses an issue with nix version 2.10, where the version comparison using `substring 0 3` will think that the nix version is 2.1, thus failing the check for versions >= 2.4.