### PR TITLE
Overrides: cryptography 38.0.1

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -327,6 +327,7 @@ lib.composeManyExtensions [
             "36.0.2" = "1a0ni1a3dbv2dvh6gx2i54z8v5j9m6asqg97kkv7gqb1ivihsbp8";
             "37.0.2" = "sha256-qvrxvneoBXjP96AnUPyrtfmCnZo+IriHR5HbtWQ5Gk8=";
             "37.0.4" = "sha256-f8r6QclTwkgK20CNe9i65ZOqvSUeDc4Emv6BFBhh1hI";
+            "38.0.1" = "sha256-o8l13fnfEUvUdDasq3LxSPArozRHKVsZfQg9DNR6M6Q=";
           }.${version} or (
             lib.warn "Unknown cryptography version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
Ran into this issue while building `zigpy`.

```
trace: warning: Unknown cryptography version: '38.0.1'. Please update getCargoHash.
[1/12/65 built, 36 copied (1502.3/1502.5 MiB), 241.3 MiB DL] building cryptography-38.0.1-vendor.tar.gz (buil

error: hash mismatch in fixed-output derivation '/nix/store/yj3wci62jqhkv83wi1d53awpcsb5wjhb-cryptography-38.0.1-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-o8l13fnfEUvUdDasq3LxSPArozRHKVsZfQg9DNR6M6Q=
error: 1 dependencies of derivation '/nix/store/09l5szr64c7hrngc5kyg2klhw0jcy538-python3.10-cryptography-38.0.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/68hqsyh7nhdhzkh7lawl20jnvlcfzyk3-python3.10-zigpy-0.50.3.drv' failed to build
```