### PR TITLE
Allow legacy package indices to return absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ artifacts
 poetry2nix-flamegraph.svg
 .direnv
 flake.lock
+
+.idea/

--- a/fetch_from_legacy.py
+++ b/fetch_from_legacy.py
@@ -80,14 +80,23 @@ if package_filename not in parser.sources:
     exit(1)
 
 package_file = open(package_filename, "wb")
-# Sometimes the href is a relative path
-if urlparse(parser.sources[package_filename]).netloc == "":
+# Sometimes the href is a relative or absolute path within the index's domain.
+indicated_url = urlparse(parser.sources[package_filename])
+if indicated_url.netloc == "":
     parsed_url = urlparse(index_url)
+
+    if indicated_url.path.startswith("/"):
+        # An absolute path within the index's domain.
+        path = parser.sources[package_filename]
+    else:
+        # A relative path.
+        path = parsed_url.path + "/" + parser.sources[package_filename]
+
     package_url = urlunparse(
         (
             parsed_url.scheme,
             parsed_url.netloc,
-            parsed_url.path + "/" + parser.sources[package_filename],
+            path,
             None,
             None,
             None,


### PR DESCRIPTION
Fixes #718.

I don't know how best to test this. It looks like the tests we currently have are all integration tests (`tests/legacy/`), and the Torch repo (which is the one I found that displays this behaviour) is fast-moving; the tests will break within about a month if I test against Torch. I have tested this locally against the Torch repo, though.