### PR TITLE
Overrides: ftfy, shortuuid, contourpy, omegaconf, opencv-python-headless

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -435,6 +435,9 @@
   "frozenlist": [
     "cython"
   ],
+  "ftfy": [
+    "poetry"
+  ],
   "funcparserlib": [
     "poetry-core"
   ],
@@ -1551,6 +1554,9 @@
   ],
   "shexjsg": [
     "pbr"
+  ],
+  "shortuuid": [
+    "poetry"
   ],
   "simplisafe-python": [
     "poetry-core"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -277,6 +277,12 @@ lib.composeManyExtensions [
           )
         );
 
+      contourpy = super.contourpy.overridePythonAttrs (
+        old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ self.pybind11 ];
+        }
+      );
+
       cloudflare = super.cloudflare.overridePythonAttrs (
         old: {
           postPatch = ''
@@ -1235,6 +1241,12 @@ lib.composeManyExtensions [
         }
       );
 
+      omegaconf = super.omegaconf.overridePythonAttrs (
+        old: {
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.jdk ];
+        }
+      );
+
       open3d = super.open3d.overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ (with pkgs; [
           udev
@@ -1243,13 +1255,16 @@ lib.composeManyExtensions [
         autoPatchelfIgnoreMissingDeps = true;
       });
 
-      opencv-python = super.opencv-python.overridePythonAttrs (
+      _opencv-python-override =
         old: {
           nativeBuildInputs = [ pkgs.cmake ] ++ old.nativeBuildInputs;
           buildInputs = [ self.scikit-build ] ++ (old.buildInputs or [ ]);
           dontUseCmakeConfigure = true;
-        }
-      );
+        };
+
+      opencv-python = super.opencv-python.overridePythonAttrs self._opencv-python-override;
+
+      opencv-python-headless = super.opencv-python.overridePythonAttrs self._opencv-python-override;
 
       opencv-contrib-python = super.opencv-contrib-python.overridePythonAttrs (
         old: {


### PR DESCRIPTION
These are part of the dependency footprint of Stable Diffusion, although in fact in real life I ended up overriding `opencv-python-headless` to just point to `opencv-python` (because in the particular case of Stable Diffusion, both packages are in the footprint and they conflict).

I've tested these build on aarch64-darwin, although I haven't yet got the end-to-end test (namely "run SD") because of at least two unrelated problems (#721, and my inability to get the libjpeg dylib into the `torchvision` search path).