### PR TITLE
FastAPI hatchling

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -388,7 +388,8 @@
     "cython"
   ],
   "fastapi": [
-    "flitBuildHook"
+    { "buildSystem": "flitBuildHook", "until": "0.84.0" },
+    { "buildSystem": "hatchling", "from": "0.84.0" }
   ],
   "fastapi-restful": [
     "poetry"


### PR DESCRIPTION
Starting with version 0.84.0 fastapi uses hatchling instead of flit: https://github.com/tiangolo/fastapi/commit/4267bd1f4f716244a8087e5aa0e68c1de629cfa9