### PR TITLE
Overrides: add suds, mdit-py-plugins

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -740,6 +740,9 @@
   "mdformat": [
     "poetry-core"
   ],
+  "mdit-py-plugins": [
+    "flit-core"
+  ],
   "mdurl": [
     "flit-core"
   ],

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2048,6 +2048,12 @@ lib.composeManyExtensions [
         '';
       });
 
+      suds = super.suds.overridePythonAttrs (old: {
+        # Fix naming convention shenanigans.
+        # https://github.com/suds-community/suds/blob/a616d96b070ca119a532ff395d4a2a2ba42b257c/setup.py#L648
+        SUDS_PACKAGE = "suds";
+      });
+
       systemd-python = super.systemd-python.overridePythonAttrs (old: {
         buildInputs = old.buildInputs ++ [ pkgs.systemd ];
         nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkg-config ];


### PR DESCRIPTION
Overrides added:
1) suds - For some reason, suds deploy the same package under two different names, where the name is configured at build time via environment variable. https://github.com/suds-community/suds/blob/a616d96b070ca119a532ff395d4a2a2ba42b257c/setup.py#L648
2) mdit-py-plugins - https://github.com/executablebooks/mdit-py-plugins/blob/c35bf143fb45e8572a1488cd78a96a1bbbb92bfb/pyproject.toml#L2


