### PR TITLE
Generate a dist-info folder instead of an egg-info

### DIFF
--- a/editable.nix
+++ b/editable.nix
@@ -7,6 +7,8 @@
 }:
 let
   name = poetryLib.normalizePackageName pyProject.tool.poetry.name;
+  underscoredName = builtins.replaceStrings [ "-" ] [ "_" ] name;
+  distInfoFolder = "${underscoredName}-${pyProject.tool.poetry.version}.dist-info";
 
   # Just enough standard PKG-INFO fields for an editable installation
   pkgInfoFields = {
@@ -41,11 +43,10 @@ let
         '')
           (lib.attrValues editablePackageSources)}
 
-        # Create a very simple egg so pkg_resources can find this package
-        # See https://setuptools.readthedocs.io/en/latest/formats.html for more info on the egg format
-        mkdir "${name}.egg-info"
-        cd "${name}.egg-info"
-        ln -s ${pkgInfoFile} PKG-INFO
+        # Generate a minimal dist-info so `pkg_resources` can find this package.
+        mkdir "${distInfoFolder}"
+        cd "${distInfoFolder}"
+        ln -s ${pkgInfoFile} METADATA
         ${lib.optionalString (pyProject.tool.poetry ? plugins) ''
           ln -s ${entryPointsFile} entry_points.txt
         ''}


### PR DESCRIPTION
All we really need is a `METADATA` file, and for the folder to have dashes replaced with underscores.

This may be related to https://github.com/nix-community/poetry2nix/issues/616.

I think this probably shouldn't be merged as-is, because I'm just throwing away the egg part, but @adisbladis if you are pro implementing this at all we could:

1. Introduce a new `editablePackagesSources` argument to decide whether to use egg or dist-info style,
2. Figure out what information is essential, and add that too,
3. ???

Alternatively, this PR by itself might help people that are looking for `dist-info` files, which get picked up by libraries such as `pkg_resources.get_distribution("your-package")`.