### PR TITLE
Makes template track nixos-unstable

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -2,8 +2,11 @@
   description = "Application packaged using poetry2nix";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
-  inputs.poetry2nix.url = "github:nix-community/poetry2nix";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.poetry2nix = {
+    url = "github:nix-community/poetry2nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
   outputs = { self, nixpkgs, flake-utils, poetry2nix }:
     {


### PR DESCRIPTION
Previously, tracked nixpkgs/main which almost guarantees lots of cache misses and compiling from source.