### PR TITLE
Adds a devshell to template which includes poetry

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -30,5 +30,11 @@
         };
 
         defaultApp = pkgs.myapp;
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            (python310.withPackages (ps: with ps; [ poetry ]))
+          ];
+        };
       }));
 }


### PR DESCRIPTION
I think this makes the new template more useful, because a user can `nix flake init` with it in an existing project and then `nix develop` to get an environment with poetry already installed to start packaging their app.