### PR TITLE
Fix an infinite recursion due to setuptools and setuptools-scm

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -211,7 +211,11 @@ lib.makeScope pkgs.newScope (self: {
                   );
                 }
               )
-              (lib.reverseList compatible)
+              (lib.reverseList (
+                # To prevent bootstrapping issues we grab setuptools and setuptools-scm from nixpkgs.
+                # This means we need to filter them from poetry.lock.
+                builtins.filter (pkgMeta: pkgMeta.name != "setuptools" && pkgMeta.name != "setuptools-scm") compatible)
+              )
           );
         in
         lockPkgs // {


### PR DESCRIPTION
There is a bootstrapping issue when trying to build `setuptool-scm`, since building it (transitively) requires `setuptools-scm` itself. The same holds for `setuptools`. This "fixes" that by removing any references to `setuptools` and `setuptools-scm` from the entries gathered from `poetry.lock` with the idea that we should default to `setuptools` and `setuptools-scm` from nixpkgs.

This fixes #648, albeit quite ugly.

A better approach would be to build the versions of `setuptools` and `setuptools-scm` specified in `poetry.lock` using whatever `setuptools` and `setuptools-scm` is in nixpkgs, and use `setuptools` and `setuptools-scm` from `poetry.lock` afterwards. However, I'm not sure how to best go about this, since it would require a separate Python environment.