### PR TITLE
fiona: switch from gdal_2 to gdal

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -620,9 +620,9 @@ lib.composeManyExtensions [
 
       fiona = super.fiona.overridePythonAttrs (
         old: {
-          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.gdal_2 ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.gdal ];
           nativeBuildInputs = [
-            pkgs.gdal_2 # for gdal-config
+            pkgs.gdal # for gdal-config
           ];
         }
       );


### PR DESCRIPTION
[nixpkgs is dropping gdal_2](https://github.com/NixOS/nixpkgs/pull/195213), and fiona has supported this since 1.8.9 (released 2019-10-21).

See also: https://github.com/NixOS/nixpkgs/pull/195316