### PR TITLE
build-systems: add setuptools for various packages

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -4748,6 +4748,9 @@
   "fasttext": [
     "setuptools"
   ],
+  "faust-streaming": [
+    "setuptools"
+  ],
   "favicon": [
     "setuptools"
   ],
@@ -8457,6 +8460,9 @@
     "setuptools"
   ],
   "mockupdb": [
+    "setuptools"
+  ],
+  "mode-streaming": [
     "setuptools"
   ],
   "moderngl": [
@@ -13378,6 +13384,9 @@
   "python-sat": [
     "setuptools"
   ],
+  "python-schema-registry-client": [
+    "setuptools"
+  ],
   "python-simple-hipchat": [
     "setuptools"
   ],
@@ -15894,6 +15903,9 @@
     "setuptools"
   ],
   "svgwrite": [
+    "setuptools"
+  ],
+  "svix-ksuid": [
     "setuptools"
   ],
   "swagger-spec-validator": [


### PR DESCRIPTION
Adds setuptools as build system for faust-streaming, mode-streaming, python-schema-registry-client, and svix-ksuid. All packages I've added these overrides to recently in my own builds