### PR TITLE
fix: eval error on poetry 1.2 when a dev dependency is from git

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -202,7 +202,7 @@ lib.makeScope pkgs.newScope (self: {
                       sourceSpec = (
                         (normalizePackageSet pyProject.tool.poetry.dependencies or { }).${normalizedName}
                           or (normalizePackageSet pyProject.tool.poetry.dev-dependencies or { }).${normalizedName}
-                          or (normalizePackageSet pyProject.tool.poetry.group.dev.dependencies { }).${normalizedName} # Poetry 1.2.0+
+                          or (normalizePackageSet pyProject.tool.poetry.group.dev.dependencies or { }).${normalizedName} # Poetry 1.2.0+
                           or { }
                       );
                     }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -47,6 +47,7 @@ builtins.removeAttrs
   file-wheel-deps = callTest ./file-wheel-deps { };
   file-wheel-deps-level2 = callTest ./file-wheel-deps-level2 { };
   git-deps = callTest ./git-deps { };
+  git-deps-1_2_0 = callTest ./git-deps-1_2_0 { };
   git-deps-pinned = callTest ./git-deps-pinned { };
   in-list = callTest ./in-list { };
   cli = poetry2nix;

--- a/tests/git-deps-1_2_0/default.nix
+++ b/tests/git-deps-1_2_0/default.nix
@@ -1,0 +1,8 @@
+{ lib, poetry2nix, python3 }:
+
+poetry2nix.mkPoetryApplication {
+  python = python3;
+  pyproject = ./pyproject.toml;
+  poetrylock = ./poetry.lock;
+  src = lib.cleanSource ./.;
+}

--- a/tests/git-deps-1_2_0/poetry.lock
+++ b/tests/git-deps-1_2_0/poetry.lock
@@ -1,0 +1,22 @@
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/tartley/colorama.git"
+reference = "4321bbfda9aa190acdad05eb901d3b59439f0ec9"
+resolved_reference = "4321bbfda9aa190acdad05eb901d3b59439f0ec9"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6"
+content-hash = "cf3328f9b1d26a4b56fa6280838582940d6af2352ed39272c062503e302b8445"
+
+[metadata.files]
+colorama = []

--- a/tests/git-deps-1_2_0/pyproject.toml
+++ b/tests/git-deps-1_2_0/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "git-deps"
+version = "0.1.0"
+description = "poetry2nix test"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+
+[tool.poetry.group.dev.dependencies]
+colorama = { git = "https://github.com/tartley/colorama.git", rev = "4321bbfda9aa190acdad05eb901d3b59439f0ec9" }
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This fixes an issue I was having when specifying a dev dependency via git. Hopefully this is the right way. The test I have added passed once I did the fix.

The issue was:
```
error: attempt to call something which is not a function but a set

       at /nix/store/fnmpdpj4acacb9ij2sskjj5rdpkp618i-source/default.nix:205:31:

          204|                           or (normalizePackageSet pyProject.tool.poetry.dev-dependencies or { }).${normalizedName}
          205|                           or (normalizePackageSet pyProject.tool.poetry.group.dev.dependencies { }).${normalizedName} # Poetry 1.2.0+
             |                               ^
          206|                           or { }
```