### PR TITLE
Add overrides for arpy, pydpkg

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -900,6 +900,9 @@
   "arpeggio": [
     "setuptools"
   ],
+  "arpy": [
+    "setuptools"
+  ],
   "arrayqueues": [
     "setuptools"
   ],
@@ -11200,6 +11203,9 @@
   ],
   "pydot": [
     "setuptools"
+  ],
+  "pydpkg": [
+    "poetry"
   ],
   "pydrive2": [
     "setuptools"


### PR DESCRIPTION
Without this change, my project that depends on these two packages would only work with `preferWheels = true`.

Would be happy to push these deps upstream as well (or instead), but I'm not really sure how that would work— the sources are here:

- https://github.com/viraptor/arpy/blob/master/setup.py
- https://github.com/memory/python-dpkg/blob/master/pyproject.toml

Honestly it's kind of surprising that `setuptools` especially needs to be explicitly stated as a dep.