### PR TITLE
Add overrides for tensorflow-macos

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7647,6 +7647,9 @@
   "libasyncns": [
     "setuptools"
   ],
+  "libclang": [
+    "setuptools"
+  ],
   "libcloud": [
     "setuptools"
   ],

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2231,9 +2231,7 @@ lib.composeManyExtensions [
 
       tensorflow-macos = super.tensorflow-macos.overridePythonAttrs (
         old: {
-          postInstall = ''
-            rm $out/bin/tensorboard
-          '';
+          postInstall = self.tensorflow.postInstall;
         }
       );
 

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2229,6 +2229,14 @@ lib.composeManyExtensions [
         }
       );
 
+      tensorflow-macos = super.tensorflow-macos.overridePythonAttrs (
+        old: {
+          postInstall = ''
+            rm $out/bin/tensorboard
+          '';
+        }
+      );
+
       tensorpack = super.tensorpack.overridePythonAttrs (
         old: {
           postPatch = ''


### PR DESCRIPTION
This adds the direct override for `tensorflow-macos`, and adds `setuptools` as `buildInputs` for three of its dependencies.
With this change, the only user requirement to get `tensorflow-macos` working is a workaround for #750.

I was unsure of a few things.

1.  This works with `buildInputs`, so I've used that (rather than, say `propagatedBuildInputs`) — I presume this is the correct choice?

2.  The direct overrides for `tensorflow-macos` should probably be the same as those for `tensorflow` itself, but I don't know whether that is desirable.
    If it is not, then the final commit can be dropped.
    (If it is then the latter two commits should probably be merged.)

I've backported the changes from a personal override; I don't really know what the testing policy is, here.

Thanks; happy to contribute this upstream!
