### PR TITLE
Add some missing build systems

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -3925,6 +3925,9 @@
   "django-treebeard": [
     "setuptools"
   ],
+  "django-types": [
+    "poetry-core"
+  ],
   "django-versatileimagefield": [
     "setuptools"
   ],
@@ -3962,6 +3965,9 @@
   ],
   "djangorestframework-stubs": [
     "setuptools"
+  ],
+  "djangorestframework-types": [
+    "poetry"
   ],
   "djmail": [
     "setuptools"
@@ -15256,6 +15262,9 @@
     "setuptools"
   ],
   "slugid": [
+    "setuptools"
+  ],
+  "slumber": [
     "setuptools"
   ],
   "sly": [


### PR DESCRIPTION
Add missing build systems for `django-types`, `djangorestframework-types` and `slumber`.