### PR TITLE
Fix cryptography `override` not allowing subsequent call to `overridePythonAttrs`

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -390,7 +390,7 @@ lib.composeManyExtensions [
           scrypto =
             if isWheel then
               (
-                super.cryptography.override { preferWheel = true; }
+                super.cryptography.overridePythonAttrs { preferWheel = true; }
               ) else super.cryptography;
         in
         scrypto.overridePythonAttrs


### PR DESCRIPTION
using `.override` creates a derivation that no longer supports `overridePythonAttrs`, so following call to `scrypto.overridePythonAttrs`` fails.

using `overridePythonAttrs` makes the resulting package able to have `overridePythonAttrs` called again.