### PR TITLE
override: multiaddr

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -8698,6 +8698,9 @@
   "multi-key-dict": [
     "setuptools"
   ],
+  "multiaddr": [
+    "setuptools"
+  ],
   "multidict": [
     "setuptools"
   ],


### PR DESCRIPTION
A private project I'm building would otherwise fail with `ModuleNotFoundError: No module named 'setuptools'`. 