### PR TITLE
Extend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For more information, see [the announcement post on the Tweag blog](https://www.
 
 ## Table of contents
 - [API](#api)
+- [FAQ](#FAQ)
 - [How-to guides](#how-to-guides)
 - [Using the flake](#using-the-flake)
 - [Contributing](#contributing)
@@ -294,6 +295,21 @@ in pkgs.poetry2nix.mkPoetryApplication {
   projectDir = ./.;
 }
 ```
+
+
+## FAQ
+
+**Q.** I'm experiencing one of the following errors, what do I do?
+
+- ModuleNotFoundError: No module named 'setuptools'
+- ModuleNotFoundError: No module named 'pdm'
+- ModuleNotFoundError: No module named 'setuptools-scm'
+- ModuleNotFoundError: No module named 'poetry-core'
+- ModuleNotFoundError: No module named 'flit'
+- ModuleNotFoundError: No module named 'flit-core'
+- ModuleNotFoundError: No module named 'flit-scm'
+
+**A.** Have a look at the following document [edgecase.md](./docs/edgecases.md)
 
 ## How-to guides
 - [Package and deploy Python apps faster with Poetry and Nix](https://www.youtube.com/watch?v=TbIHRHy7_JM)

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -1,6 +1,8 @@
 # Edge cases
+
 ## Preamble
-The python ecosystem has a very long history.
+
+The Python ecosystem has a very long history.
 Over the years, an uncountable number of modules have been created, but more importantly, the assembly technology of these modules has changed many times.
 `ez_install`, `setuptools`, `distutils`, eggs, `pip`, wheels, PEP-518, PEP-517, `flit`, `poetry`.
 All this diversity creates great difficulties.
@@ -18,47 +20,47 @@ We have tried to collect here and describe typical errors and ways to eliminate 
 
 ## Cases
 
-#### ModuleNotFoundError: No module named 'poetry'
-**Conditions:** you have declared a dependency on git repository with the python package.
-And this package uses poetry as a build tool.
+#### ModuleNotFoundError: No module named 'PACKAGENAME'
+
+**Conditions:** You have declared a dependency in a repository.
+And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.).
 So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip.
-But pip requires poetry to build this package. And that’s when an error occurs.
+But pip requires `PACKAGENAME` to build this package. And that’s when an error occurs.
 
-**Solution:** in order to make dependency build we need to override it build dependencies by adding poetry  package to it.
+**Solution:** In order to make the dependency build, we need to override its build dependencies by adding the `PACKAGENAME` package to it.
 
-**Example:** let's consider situation when our package has declared `git` dependency in `pyproject.toml` on `extralib`, which uses poetry to be built.
+**Example:** Let's consider the situation when our package has declared `django-floppyforms` as a dependency in `pyproject.toml`, which uses `PACKAGENAME` to be built.
 And we have this declaration in our Nix definition:
+
 ```
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
 }
 ```
-And trying to build it get us next error log
+
+And trying to build it results in the following error log
 <details>
   <summary>error log (click to expand)</summary>
 
 ```
+Sourcing python-remove-tests-dir-hook
 Sourcing python-catch-conflicts-hook.sh
 Sourcing python-remove-bin-bytecode-hook.sh
-Sourcing pip-build-hook
-Using pipBuildPhase
-Using pipShellHook
 Sourcing pip-install-hook
 Using pipInstallPhase
 Sourcing python-imports-check-hook.sh
 Using pythonImportsCheckPhase
 Sourcing python-namespaces-hook
+Sourcing pip-build-hook
+Using pipBuildPhase
+Using pipShellHook
 @nix { "action": "setPhase", "phase": "unpackPhase" }
 unpacking sources
-unpacking source archive /nix/store/f2mb5sy6vxm81sy5apzvbxmnvj8f62la-source
-source root is source
-setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/extralib/utils.py
+unpacking source archive /nix/store/w1gk95sf5lknw0mxav5gsvcijcwfqkwh-django-floppyforms-1.9.0.tar.gz
+source root is django-floppyforms-1.9.0
+setting SOURCE_DATE_EPOCH to timestamp 1589942379 of file django-floppyforms-1.9.0/setup.cfg
 @nix { "action": "setPhase", "phase": "patchPhase" }
 patching sources
-Removing path dependencies
-Finished removing path dependencies
-Removing git dependencies
-Finished removing git dependencies
 @nix { "action": "setPhase", "phase": "configurePhase" }
 configuring
 no configure script, doing nothing
@@ -67,99 +69,91 @@ building
 Executing pipBuildPhase
 Creating a wheel...
 WARNING: The directory '/homeless-shelter/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
-Ignoring indexes: https://pypi.org/simple
-Created temporary directory: /build/pip-ephem-wheel-cache-oluqv9z9
-Created temporary directory: /build/pip-req-tracker-6nbzvq94
-Initialized build tracking at /build/pip-req-tracker-6nbzvq94
-Created build tracker: /build/pip-req-tracker-6nbzvq94
-Entered build tracker: /build/pip-req-tracker-6nbzvq94
-Created temporary directory: /build/pip-wheel-ecarqqhj
-Processing /build/source
-  Created temporary directory: /build/pip-req-build-thqopu_1
-  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
-   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
-  Added file:///build/source to build tracker '/build/pip-req-tracker-6nbzvq94'
-    Created temporary directory: /build/pip-modern-metadata-5otx3b_0
-    Running command /nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/bin/python3.9 /nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /build/tmp8cfof26u
-    Preparing wheel metadata ... done
+Processing /build/django-floppyforms-1.9.0
+  Running command Preparing metadata (pyproject.toml)
+  Preparing metadata (pyproject.toml) ... done
 ERROR: Exception:
 Traceback (most recent call last):
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 180, in _main
-    status = self.run(options, args)
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 167, in exc_logging_wrapper
+    status = run_func(*args)
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 247, in wrapper
     return func(self, options, args)
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/commands/wheel.py", line 142, in run
-    requirement_set = resolver.resolve(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 103, in resolve
-    r = self.factory.make_requirement_from_install_req(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 429, in make_requirement_from_install_req
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/commands/wheel.py", line 145, in run
+    requirement_set = resolver.resolve(reqs, check_supported_wheels=True)
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 73, in resolve
+    collected = self.factory.collect_root_requirements(root_reqs)
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 491, in collect_root_requirements
+    req = self._make_requirement_from_install_req(
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 453, in _make_requirement_from_install_req
     cand = self._make_candidate_from_link(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 200, in _make_candidate_from_link
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 206, in _make_candidate_from_link
     self._link_candidate_cache[link] = LinkCandidate(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 306, in __init__
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 297, in __init__
     super().__init__(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 151, in __init__
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 162, in __init__
     self.dist = self._prepare()
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 234, in _prepare
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 231, in _prepare
     dist = self._prepare_distribution()
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 317, in _prepare_distribution
-    return self._factory.preparer.prepare_linked_requirement(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 508, in prepare_linked_requirement
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 308, in _prepare_distribution
+    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 438, in prepare_linked_requirement
     return self._prepare_linked_requirement(req, parallel_builds)
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 570, in _prepare_linked_requirement
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 524, in _prepare_linked_requirement
     dist = _get_prepared_distribution(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 60, in _get_prepared_distribution
-    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 36, in prepare_distribution_metadata
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 68, in _get_prepared_distribution
+    abstract_dist.prepare_distribution_metadata(
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 61, in prepare_distribution_metadata
     self.req.prepare_metadata()
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/req/req_install.py", line 549, in prepare_metadata
-    self.metadata_directory = self._generate_metadata()
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/req/req_install.py", line 534, in _generate_metadata
-    return generate_metadata(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_internal/operations/build/metadata.py", line 31, in generate_metadata
-    distinfo_dir = backend.prepare_metadata_for_build_wheel(
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_vendor/pep517/wrappers.py", line 184, in prepare_metadata_for_build_wheel
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 533, in prepare_metadata
+    self.metadata_directory = generate_metadata(
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/operations/build/metadata.py", line 35, in generate_metadata
+    distinfo_dir = backend.prepare_metadata_for_build_wheel(metadata_dir)
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_internal/utils/misc.py", line 706, in prepare_metadata_for_build_wheel
+    return super().prepare_metadata_for_build_wheel(
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_vendor/pep517/wrappers.py", line 188, in prepare_metadata_for_build_wheel
     return self._call_hook('prepare_metadata_for_build_wheel', {
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_vendor/pep517/wrappers.py", line 275, in _call_hook
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_vendor/pep517/wrappers.py", line 332, in _call_hook
     raise BackendUnavailable(data.get('traceback', ''))
 pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
-  File "/nix/store/11wvwr8f2dp4x8xjnrgqn3inmh418apn-python3.9-pip-21.1.3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 86, in _build_backend
+  File "/nix/store/85xz0a1v6kk26c8a78pckbylhkdmlb6g-python3.10-pip-22.2.2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 89, in _build_backend
     obj = import_module(mod_path)
-  File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
+  File "/nix/store/qc8rlhdcdxaf6dwbvv0v4k50w937fyzj-python3-3.10.8/lib/python3.10/importlib/__init__.py", line 126, in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
-  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
-  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
-  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
-  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
-  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
-  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
-ModuleNotFoundError: No module named 'poetry'
+  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
+  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
+  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
+ModuleNotFoundError: No module named 'setuptools'
 
-Removed file:///build/source from build tracker '/build/pip-req-tracker-6nbzvq94'
-Removed build tracker: '/build/pip-req-tracker-6nbzvq94'
+error (ignored): error: cannot unlink '/tmp/nix-build-python3.10-django-4.1.3.drv-1/Django-4.1.3': Directory not empty
+error: 1 dependencies of derivation '/nix/store/hz4b87s99s1lwiz2m0vwilhlh6rlfj64-python3-3.10.8-env.drv' failed to build
+error: 1 dependencies of derivation '/nix/store/60gaxbdf11lhaj9xg50cf0rr6x5v8v1z-nix-shell-env.drv' failed to build
 ```
+
+As you can see on the fourth last line it's missing `setupools` which in this case is our missing `PACKAGENAME`.
+
 </details>
 
-In order to be able to build `extralib` we should modify our nix definition as follows:
+In order to be able to build `django-floppyforms` we should modify our nix definition as follows:
+
 ```
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
-  overrides = poetry2nix.defaultPoetryOverrides.extend ( self: super: {
-    extralib = super.extralib.overridePythonAttrs (
-      old: {
-        buildInputs = (old.buildInputs or [ ]) ++ [ self.poetry ];
-      }
-    );
-  });
+  overrides = poetry2nix.defaultPoetryOverrides.extend
+    (self: super: {
+      django-floppyforms = super.django-floppyforms.overridePythonAttrs
+      (
+        old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ super.buildtools ];
+        }
+      );
+    });
 }
 ```
-This override will instruct underlying build logic to include additional build dependency into inputs of `extralib`.
+
+This override will instruct the underlying build logic to include the additional build dependency into the inputs of `django-floppyforms`.
+It might help to know that you don't need to use the full package name like `python39Packages.setupools` but can just use `setuptools` directly.
+However you have to use the name like defined in `Nixpkgs` so something like `flit_scm` becomes `flit-scm`.

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -168,4 +168,4 @@ poetry2nix.mkPoetryApplication {
 ```
 
 We recommend that you contribute your changes to `poetry2nix` so that other users can profit from them as well.
-The file with the upstream overrides can be found under the following link. It is a simple JSON file which contains the overrides in an array and sorted in alphabetical order. https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json
+The specific file with the upstream overrides is [build-systems.json](https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json). It is a simple JSON file which contains the overrides in an array and sorted in alphabetical order.

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -168,4 +168,4 @@ poetry2nix.mkPoetryApplication {
 ```
 
 We recommend that you contribute your changes to `poetry2nix` so that other users can profit from them as well.
-The file with the upstream overrides can be found here: https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json
+The file with the upstream overrides can be found under the following link. It is a simple JSON file which contains the overrides in an array and sorted in alphabetical order. https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -133,7 +133,7 @@ error: 1 dependencies of derivation '/nix/store/hz4b87s99s1lwiz2m0vwilhlh6rlfj64
 error: 1 dependencies of derivation '/nix/store/60gaxbdf11lhaj9xg50cf0rr6x5v8v1z-nix-shell-env.drv' failed to build
 ```
 
-As you can see on the fourth last line it's missing `setupools` which in this case is our missing `PACKAGENAME`.
+As you can see on the fourth last line it's missing `setuptools` which in this case is our missing `PACKAGENAME`.
 
 </details>
 
@@ -155,7 +155,7 @@ poetry2nix.mkPoetryApplication {
 ```
 
 This override will instruct the underlying build logic to include the additional build dependency into the inputs of `django-floppyforms`.
-It might help to know that you don't need to use the full package name like `python39Packages.setupools` but can just use `setuptools` directly.
+It might help to know that you don't need to use the full package name like `python39Packages.setuptools` but can just use `setuptools` directly.
 However you have to use the name like defined in `Nixpkgs` so something like `flit_scm` becomes `flit-scm`.
 
 It can happen that you need multiple overrides for your project, just work through one after the other and your project should build at the end.

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -32,7 +32,7 @@ But pip requires `PACKAGENAME` to build this package. And that’s when an error
 **Example:** Let's consider the situation when our package has declared `django-floppyforms` as a dependency in `pyproject.toml`, which uses `PACKAGENAME` to be built.
 And we have this declaration in our Nix definition:
 
-```
+``` nix
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
 }
@@ -139,7 +139,7 @@ As you can see on the fourth last line it's missing `setupools` which in this ca
 
 In order to be able to build `django-floppyforms` we should modify our nix definition as follows:
 
-```
+``` nix
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
   overrides = poetry2nix.defaultPoetryOverrides.extend
@@ -161,7 +161,7 @@ However you have to use the name like defined in `Nixpkgs` so something like `fl
 It can happen that you need multiple overrides for your project, just work through one after the other and your project should build at the end.
 Your file might then look something like this:
 
-```
+``` nix
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
   overrides = poetry2nix.defaultPoetryOverrides.extend

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -157,3 +157,30 @@ poetry2nix.mkPoetryApplication {
 This override will instruct the underlying build logic to include the additional build dependency into the inputs of `django-floppyforms`.
 It might help to know that you don't need to use the full package name like `python39Packages.setupools` but can just use `setuptools` directly.
 However you have to use the name like defined in `Nixpkgs` so something like `flit_scm` becomes `flit-scm`.
+
+It can happen that you need multiple overrides for your project, just work through one after the other and your project should build at the end.
+Your file might then look something like this:
+
+```
+poetry2nix.mkPoetryApplication {
+  projectDir = ./.;
+  overrides = poetry2nix.defaultPoetryOverrides.extend
+    (self: super: {
+      first-dependency = super.first-dependency.overridePythonAttrs
+      (
+        old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ super.buildtools ];
+        }
+      );
+      second-dependency = super.second-dependency.overridePythonAttrs
+      (
+        old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ super.pdm ];
+        }
+      );
+    });
+}
+```
+
+We recommend that you contribute your changes to `poetry2nix` so that other users can profit from them as well.
+The file with the upstream overrides can be found here: https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -147,7 +147,7 @@ poetry2nix.mkPoetryApplication {
       django-floppyforms = super.django-floppyforms.overridePythonAttrs
       (
         old: {
-          buildInputs = (old.buildInputs or [ ]) ++ [ super.buildtools ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ super.setuptools ];
         }
       );
     });

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -11,7 +11,7 @@ This is very sad, and we will inevitably face the fact that some modules can not
 
 #### ModuleNotFoundError: No module named 'PACKAGENAME'
 
-**Conditions:** You have declared a dependency in a repository. And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.). So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip. But pip requires `PACKAGENAME` to build this package. And that’s when an error occurs.
+**Conditions:** You have declared a dependency in a repository. And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.). So since `poetry2nix` prefers to download this dependencies as *sdist*, it needs to build it from the source by calling pip. But pip requires `PACKAGENAME` to build this package. And that’s when the error occurs.
 
 **Solution:** In order to make the dependency build, we need to override its build dependencies by adding the `PACKAGENAME` package to it.
 

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -156,7 +156,7 @@ poetry2nix.mkPoetryApplication {
 
 This override will instruct the underlying build logic to include the additional build dependency into the inputs of `django-floppyforms`.
 It might help to know that you don't need to use the full package name like `python39Packages.setuptools` but can just use `setuptools` directly.
-However you have to use the name like defined in `Nixpkgs` so something like `flit_scm` becomes `flit-scm`.
+Be aware that the package names are normalized according to PEP-517, so something like `flit_scm` becomes `flit-scm`.
 
 It can happen that you need multiple overrides for your project, just work through one after the other and your project should build at the end.
 Your file might then look something like this:

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -11,7 +11,7 @@ This is very sad, and we will inevitably face the fact that some modules can not
 
 #### ModuleNotFoundError: No module named 'PACKAGENAME'
 
-**Conditions:** You have declared a dependency in a repository. And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.). So since `poetry2nix` prefers to download this dependencies as *sdist*, it needs to build it from the source by calling pip. But pip requires `PACKAGENAME` to build this package. And that’s when the error occurs.
+**Conditions:** You have declared a Python package dependency. And this package uses one of the build tools mentioned above (setuptools, pdm, etc.). Since poetry2nix prefers to build from source it requires the build tool. And that’s when the error occurs.
 
 **Solution:** In order to make the dependency build, we need to override its build dependencies by adding the `PACKAGENAME` package to it.
 

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -1,18 +1,33 @@
 # Edge cases
 ## Preamble
-The python ecosystem has a very long history. Over the years, an uncountable number of modules have been created, but more importantly, the assembly technology of these modules has changed many times. `ez_install`, `setuptools`, `distutils`, eggs, `pip`, wheels, PEP-518, PEP-517, `flit`, `poetry`. All this diversity creates great difficulties. Poetry, on the one hand, being a build system, can abandon the setuptools and distutils formats, but at the same time, being a dependency installation and management system, it must support all current distribution technologies. And it can do this without revealing the internal structure and the machinery behind curtains. In other words, when you use Poetry, both `setuptools`, `pip` and other build tools can be used to install some modules, and this happens without formally declaring dependence on these tools.
+The python ecosystem has a very long history.
+Over the years, an uncountable number of modules have been created, but more importantly, the assembly technology of these modules has changed many times.
+`ez_install`, `setuptools`, `distutils`, eggs, `pip`, wheels, PEP-518, PEP-517, `flit`, `poetry`.
+All this diversity creates great difficulties.
+Poetry, on the one hand, being a build system, can abandon the setuptools and distutils formats, but at the same time, being a dependency installation and management system, it must support all current distribution technologies.
+And it can do this without revealing the internal structure and the machinery behind curtains.
+In other words, when you use Poetry, both `setuptools`, `pip` and other build tools can be used to install some modules, and this happens without formally declaring dependence on these tools.
 
-All these factors can cause the module not to be assembled or installed in a certain environment. Nix is a much stricter ecosystem, it has more formal requirements, but at the same time more guarantees. And since `poetry2nix` relies on Nix and its strict rules in its work, there are many rough edges and inaccuracies in the metadata on pypi.org leads to errors.
-This is very sad, and we will inevitably face the fact that some modules can not be installed, can not be built, or just cause errors, have unnecessary or missing direct and transitive dependencies. However, Nix is a very flexible system that allows you to modify some aspects of the module with pinpoint accuracy, without changing the source code of the module (and sometimes changing it). This is what this section is dedicated to. We have tried to collect here and describe typical errors and ways to eliminate them.
+All these factors can cause the module not to be assembled or installed in a certain environment.
+Nix is a much stricter ecosystem, it has more formal requirements, but at the same time more guarantees.
+And since `poetry2nix` relies on Nix and its strict rules in its work, there are many rough edges and inaccuracies in the metadata on pypi.org leads to errors.
+This is very sad, and we will inevitably face the fact that some modules can not be installed, can not be built, or just cause errors, have unnecessary or missing direct and transitive dependencies.
+However, Nix is a very flexible system that allows you to modify some aspects of the module with pinpoint accuracy, without changing the source code of the module (and sometimes changing it).
+This is what this section is dedicated to.
+We have tried to collect here and describe typical errors and ways to eliminate them.
 
 ## Cases
 
 #### ModuleNotFoundError: No module named 'poetry'
-**Conditions:** you have declared a dependency on git repository with the python package. And this package uses poetry as a build tool. So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip. But pip requires poetry to build this package. And that’s when an error occurs.
+**Conditions:** you have declared a dependency on git repository with the python package.
+And this package uses poetry as a build tool.
+So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip.
+But pip requires poetry to build this package. And that’s when an error occurs.
 
 **Solution:** in order to make dependency build we need to override it build dependencies by adding poetry  package to it.
 
-**Example:** let's consider situation when our package has declared `git` dependency in `pyproject.toml` on `extralib`, which uses poetry to be built. And we have this declaration in our Nix definition:
+**Example:** let's consider situation when our package has declared `git` dependency in `pyproject.toml` on `extralib`, which uses poetry to be built.
+And we have this declaration in our Nix definition:
 ```
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -2,35 +2,20 @@
 
 ## Preamble
 
-The Python ecosystem has a very long history.
-Over the years, an uncountable number of modules have been created, but more importantly, the assembly technology of these modules has changed many times.
-`ez_install`, `setuptools`, `distutils`, eggs, `pip`, wheels, PEP-518, PEP-517, `flit`, `poetry`.
-All this diversity creates great difficulties.
-Poetry, on the one hand, being a build system, can abandon the setuptools and distutils formats, but at the same time, being a dependency installation and management system, it must support all current distribution technologies.
-And it can do this without revealing the internal structure and the machinery behind curtains.
-In other words, when you use Poetry, both `setuptools`, `pip` and other build tools can be used to install some modules, and this happens without formally declaring dependence on these tools.
+The Python ecosystem has a very long history. Over the years, an uncountable number of modules have been created, but more importantly, the assembly technology of these modules has changed many times. `ez_install`, `setuptools`, `distutils`, eggs, `pip`, wheels, PEP-518, PEP-517, `flit`, `poetry`. All this diversity creates great difficulties. Poetry, on the one hand, being a build system, can abandon the setuptools and distutils formats, but at the same time, being a dependency installation and management system, it must support all current distribution technologies. And it can do this without revealing the internal structure and the machinery behind curtains. In other words, when you use Poetry, both `setuptools`, `pip` and other build tools can be used to install some modules, and this happens without formally declaring dependence on these tools.
 
-All these factors can cause the module not to be assembled or installed in a certain environment.
-Nix is a much stricter ecosystem, it has more formal requirements, but at the same time more guarantees.
-And since `poetry2nix` relies on Nix and its strict rules in its work, there are many rough edges and inaccuracies in the metadata on pypi.org leads to errors.
-This is very sad, and we will inevitably face the fact that some modules can not be installed, can not be built, or just cause errors, have unnecessary or missing direct and transitive dependencies.
-However, Nix is a very flexible system that allows you to modify some aspects of the module with pinpoint accuracy, without changing the source code of the module (and sometimes changing it).
-This is what this section is dedicated to.
-We have tried to collect here and describe typical errors and ways to eliminate them.
+All these factors can cause the module not to be assembled or installed in a certain environment. Nix is a much stricter ecosystem, it has more formal requirements, but at the same time more guarantees. And since `poetry2nix` relies on Nix and its strict rules in its work, there are many rough edges and inaccuracies in the metadata on pypi.org leads to errors.
+This is very sad, and we will inevitably face the fact that some modules can not be installed, can not be built, or just cause errors, have unnecessary or missing direct and transitive dependencies. However, Nix is a very flexible system that allows you to modify some aspects of the module with pinpoint accuracy, without changing the source code of the module (and sometimes changing it). This is what this section is dedicated to. We have tried to collect here and describe typical errors and ways to eliminate them.
 
 ## Cases
 
 #### ModuleNotFoundError: No module named 'PACKAGENAME'
 
-**Conditions:** You have declared a dependency in a repository.
-And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.).
-So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip.
-But pip requires `PACKAGENAME` to build this package. And that’s when an error occurs.
+**Conditions:** You have declared a dependency in a repository. And this package uses `PACKAGENAME` as a build tool. Where `PACKAGENAME` most likely is one of the tools mentioned above (`setuptools`, `pdm`, etc.). So since `poetry2nix` cannot obtain this dependency in form of a wheel, it needs to build it from the source by calling pip. But pip requires `PACKAGENAME` to build this package. And that’s when an error occurs.
 
 **Solution:** In order to make the dependency build, we need to override its build dependencies by adding the `PACKAGENAME` package to it.
 
-**Example:** Let's consider the situation when our package has declared `django-floppyforms` as a dependency in `pyproject.toml`, which uses `PACKAGENAME` to be built.
-And we have this declaration in our Nix definition:
+**Example:** Let's consider the situation when our package has declared `django-floppyforms` as a dependency in `pyproject.toml`, which uses `PACKAGENAME` to be built. And we have this declaration in our Nix definition:
 
 ``` nix
 poetry2nix.mkPoetryApplication {


### PR DESCRIPTION
After battling with the `ModuleNotFoundError` I thought I might try to help with making the docs a bit clearer.
At least the I think that the changes would've helped me.

I was especially confused that you used `poetry` in the example I couldn't' really separate it from `peotry2nix` when debugging the error.
In addition the example used `self.poetry` and in the Matrix chat I was told (and got it working) that I had to use `super.poetry`.