### PR TITLE
build-systems: blue

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -2012,6 +2012,9 @@
     "setuptools",
     "setuptools-scm"
   ],
+  "blue": [
+    "setuptools"
+  ],
   "bluemaestro-ble": [
     "poetry-core",
     "setuptools"


### PR DESCRIPTION
Make it possible to build projects depending on [blue](https://blue.readthedocs.io/).

Tested with the following files:

- <details><summary><tt>shell.nix</tt> (click to expand)</summary>

  ```nix
  { pkgs ? import <nixpkgs> { }
  , poetry2nix ? import ~/dev/poetry2nix { }
  }:
  let
    myAppEnv = poetry2nix.mkPoetryEnv {
      projectDir = ./.;
      editablePackageSources = {
        my-app = ./src;
      };
    };
  in myAppEnv.env
  ```
  Where `~/dev/poetry2nix` is a clone of this git repo with this change.

  </details>
- <details><summary><tt>pyproject.toml</tt> (click to expand)</summary>

  ```toml
  [tool.poetry]
  name = "foo"
  version = "0.1.0"
  description = ""
  authors = ["Raphael Borun Das Gupta <git@raphael.dasgupta.ch>"]
  readme = "README.md"
  
  [tool.poetry.dependencies]
  python = "^3.10"
  
  [tool.poetry.group.dev.dependencies]
  blue = "^0.9.1"
  
  [build-system]
  requires = ["poetry-core"]
  build-backend = "poetry.core.masonry.api"
  ```

  </details>
- <details><summary><tt>poetry.lock</tt> (click to expand)</summary>

  ```toml
  [[package]]
  name = "black"
  version = "22.1.0"
  description = "The uncompromising code formatter."
  category = "dev"
  optional = false
  python-versions = ">=3.6.2"
  
  [package.dependencies]
  click = ">=8.0.0"
  mypy-extensions = ">=0.4.3"
  pathspec = ">=0.9.0"
  platformdirs = ">=2"
  tomli = ">=1.1.0"
  
  [package.extras]
  colorama = ["colorama (>=0.4.3)"]
  d = ["aiohttp (>=3.7.4)"]
  jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
  uvloop = ["uvloop (>=0.15.2)"]
  
  [[package]]
  name = "blue"
  version = "0.9.1"
  description = "Blue -- Some folks like black but I prefer blue."
  category = "dev"
  optional = false
  python-versions = "*"
  
  [package.dependencies]
  black = "22.1.0"
  flake8 = ">=3.8,<5.0.0"
  
  [[package]]
  name = "click"
  version = "8.1.3"
  description = "Composable command line interface toolkit"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  
  [package.dependencies]
  colorama = {version = "*", markers = "platform_system == \"Windows\""}
  
  [[package]]
  name = "colorama"
  version = "0.4.6"
  description = "Cross-platform colored terminal text."
  category = "dev"
  optional = false
  python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
  
  [[package]]
  name = "flake8"
  version = "4.0.1"
  description = "the modular source code checker: pep8 pyflakes and co"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  
  [package.dependencies]
  mccabe = ">=0.6.0,<0.7.0"
  pycodestyle = ">=2.8.0,<2.9.0"
  pyflakes = ">=2.4.0,<2.5.0"
  
  [[package]]
  name = "mccabe"
  version = "0.6.1"
  description = "McCabe checker, plugin for flake8"
  category = "dev"
  optional = false
  python-versions = "*"
  
  [[package]]
  name = "mypy-extensions"
  version = "0.4.3"
  description = "Experimental type system extensions for programs checked with the mypy typechecker."
  category = "dev"
  optional = false
  python-versions = "*"
  
  [[package]]
  name = "pathspec"
  version = "0.10.2"
  description = "Utility library for gitignore style pattern matching of file paths."
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  
  [[package]]
  name = "platformdirs"
  version = "2.5.4"
  description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  
  [package.extras]
  docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
  test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
  
  [[package]]
  name = "pycodestyle"
  version = "2.8.0"
  description = "Python style guide checker"
  category = "dev"
  optional = false
  python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
  
  [[package]]
  name = "pyflakes"
  version = "2.4.0"
  description = "passive checker of Python programs"
  category = "dev"
  optional = false
  python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
  
  [[package]]
  name = "tomli"
  version = "2.0.1"
  description = "A lil' TOML parser"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  
  [metadata]
  lock-version = "1.1"
  python-versions = "^3.10"
  content-hash = "6c529545966a02eb40f7e7d4d53f2e4af9de5fbd84c783f1e1b9976c3f7f4f75"
  
  [metadata.files]
  black = [
      {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
      {file = "black-22.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866"},
      {file = "black-22.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71"},
      {file = "black-22.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab"},
      {file = "black-22.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5"},
      {file = "black-22.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a"},
      {file = "black-22.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0"},
      {file = "black-22.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba"},
      {file = "black-22.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1"},
      {file = "black-22.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8"},
      {file = "black-22.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28"},
      {file = "black-22.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912"},
      {file = "black-22.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3"},
      {file = "black-22.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"},
      {file = "black-22.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61"},
      {file = "black-22.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd"},
      {file = "black-22.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f"},
      {file = "black-22.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0"},
      {file = "black-22.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c"},
      {file = "black-22.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2"},
      {file = "black-22.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321"},
      {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
      {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
  ]
  blue = [
      {file = "blue-0.9.1-py3-none-any.whl", hash = "sha256:037742c072c58a2ff024f59fb9164257b907f97f8f862008db3b013d1f27cc22"},
      {file = "blue-0.9.1.tar.gz", hash = "sha256:76b4f26884a8425042356601d80773db6e0e14bebaa7a59d7c54bf8cef2e2af5"},
  ]
  click = [
      {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
      {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
  ]
  colorama = [
      {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
      {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
  ]
  flake8 = [
      {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
      {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
  ]
  mccabe = [
      {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
      {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
  ]
  mypy-extensions = [
      {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
      {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
  ]
  pathspec = [
      {file = "pathspec-0.10.2-py3-none-any.whl", hash = "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5"},
      {file = "pathspec-0.10.2.tar.gz", hash = "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"},
  ]
  platformdirs = [
      {file = "platformdirs-2.5.4-py3-none-any.whl", hash = "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"},
      {file = "platformdirs-2.5.4.tar.gz", hash = "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7"},
  ]
  pycodestyle = [
      {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
      {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
  ]
  pyflakes = [
      {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
      {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
  ]
  tomli = [
      {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
      {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
  ]
  ```

  </details>

by running
```bash
nix-shell --command 'blue --version'
```