### PR TITLE
Parse pypi source indexes with basic auth creds

### DIFF
--- a/fetch_from_legacy.py
+++ b/fetch_from_legacy.py
@@ -60,6 +60,12 @@ context = ssl.create_default_context()
 context.check_hostname = False
 context.verify_mode = ssl.CERT_NONE
 
+# Extract out username/password from index_url, if present.
+parsed_url = urlparse(index_url)
+username = parsed_url.username or username
+password = parsed_url.password or password
+index_url = parsed_url._replace(netloc=parsed_url.netloc.rpartition("@")[-1]).geturl()
+
 req = urllib.request.Request(index_url)
 if username and password:
     import base64


### PR DESCRIPTION
## Summary

This change parses the `index_url` of the source and extracts out the Basic Authentication `username` and `password` credentials, if they exist, to be used by the existing mechanism for netrc parsing.

The `index_url` is then reconstructed without the credentials, so that the rest of the index fetch can proceed as expected.

## Details

Previously, if one had a `pyproject.toml` with a custom source that had basic auth credentials in the URL, e.g.

```toml
[[tool.poetry.source]]
name = "private_source"
url = "https://username:password@pypi.example.com/pypi"
```

The `fetch_from_legacy.py` script would fail to parse, erronously splitting on the `:` thinking that whatever came after it was a numeric port identifier ala `https://example.com:8080`.

While embedding authentication credentials in an index URL that is then committed to a `pyproject.toml` is not what one would consider best practice (there are several alternative approaches that keep credentials out of the `pyproject.toml` file), it _is_ supported by the direct usage of Poetry, and those legacy projects should still be able to utilize `poetry2nix`.

## Implementation

For the sake of clarity and consistency, the simplest approach that would not interfere with existing behaviours was selected. There were no existing tests regarding source `index_url` parsing, which made me a bit unsure as to how you would like this particular changset to be tested. Please let me know, and I'll be happy to amend the PR.

## References

Closes #846