### PR TITLE
scikit-image: add setuptools

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14949,7 +14949,8 @@
     "setuptools-scm"
   ],
   "scikit-image": [
-    "cython"
+    "cython",
+    "setuptools"
   ],
   "scikit-learn": [
     "cython",


### PR DESCRIPTION
It seems to be needed (like the other scikit packages)