### PR TITLE
open3d: patch reference to openmp

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1343,6 +1343,12 @@ lib.composeManyExtensions [
               ];
             })
         ];
+
+        # Patch the dylib in the binary distribution to point to the nix build of libomp
+        preFixup = lib.optionalString (stdenv.isDarwin && lib.versionAtLeast super.open3d.version "0.16.0") ''
+          install_name_tool -change /opt/homebrew/opt/libomp/lib/libomp.dylib ${pkgs.llvmPackages.openmp}/lib/libomp.dylib $out/lib/python*/site-packages/open3d/cpu/pybind.cpython-*-darwin.so
+        '';
+
         # TODO(Sem Mulder): Add overridable flags for CUDA/PyTorch/Tensorflow support.
         autoPatchelfIgnoreMissingDeps = true;
       });


### PR DESCRIPTION
Patch the dylib in the binary distribution to point to the nix build of libomp