### PR TITLE
mkdocs: fix `babel` package case

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2729,7 +2729,7 @@ lib.composeManyExtensions [
       });
 
       mkdocs = super.mkdocs.overridePythonAttrs (old: {
-        propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ self.Babel ];
+        propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ self.babel ];
       });
     }
   )


### PR DESCRIPTION
Apparently this needs to be lowercase.