### PR TITLE
fix: Use setuptools for nbformat 5.4.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9066,11 +9066,11 @@
   "nbformat": [
     {
       "buildSystem": "setuptools",
-      "until": "5.4.0"
+      "until": "5.5.0"
     },
     {
       "buildSystem": "flit-core",
-      "from": "5.4.0",
+      "from": "5.5.0",
       "until": "5.6.0"
     },
     {


### PR DESCRIPTION
As per the change log
<https://github.com/jupyter/nbformat/blob/e5dd9089c38b039e7fb874db9e141e01e2cce718/CHANGELOG.md#550>.