### PR TITLE
fix: revert mkdocs-material override

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2739,20 +2739,6 @@ lib.composeManyExtensions [
       mkdocs = super.mkdocs.overridePythonAttrs (old: {
         propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ self.babel ];
       });
-
-      # hatch-requirements-txt has a huge set of circular dependencies which
-      # are only used at build time, and none of which are required to use
-      # mkdocs-material as a dependency, so we remove the part of
-      # pyproject.toml that requires it
-      mkdocs-material = super.mkdocs-material.overridePythonAttrs (old: {
-        postPatch = pkgs.optionalString (lib.versionAtLeast old.version "8.5.3") ''
-          substituteInPlace pyproject.toml \
-            --replace ', "hatch-requirements-txt"' "" \
-            --replace '"hatch-requirements-txt",' "" \
-            --replace '[tool.hatch.metadata.hooks.requirements_txt]' "" \
-            --replace 'filename = "requirements.txt"' ""
-        '';
-      });
     }
   )
 


### PR DESCRIPTION
This partially reverts #865, since the override there doesn't work with `preferWheels = true;`.