### PR TITLE
overrides: build-systems: add poetry-core to hvac

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -6563,7 +6563,14 @@
     "setuptools"
   ],
   "hvac": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "1.0.0"
+    },
+    {
+      "buildSystem": "poetry-core",
+      "from": "1.0.0"
+    }
   ],
   "hvplot": [
     "setuptools"


### PR DESCRIPTION
hvac migrated their build system to poetry-core in this commit: https://github.com/hvac/hvac/commit/0ef445367afa4eb0ed5b85fa0d6658cf033f5751

I don't know if we should keep setuptools in the list for compatibility with older versions, let me know what you think.