### PR TITLE
overrides: build-systems: add hatchling to prettytable

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10755,8 +10755,22 @@
     "setuptools"
   ],
   "prettytable": [
-    "setuptools",
-    "setuptools-scm"
+    {
+      "buildSystem": "setuptools",
+      "until": "3.5.0"
+    },
+    {
+      "buildSystem": "setuptools-scm",
+      "until": "3.5.0"
+    },
+    {
+      "buildSystem": "hatch-vcs",
+      "from": "3.5.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "3.5.0"
+    }
   ],
   "primecountpy": [
     "cython",


### PR DESCRIPTION
Changed their build system in https://github.com/jazzband/prettytable/commit/fabac93cb908418037c638a3303fd217da28ab10

I left setuptools as I don't know if we should keep it for compatibility with older versions of the package.