### PR TITLE
overrides: drop unused pkgs.xlibsWrapper package

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1682,7 +1682,6 @@ lib.composeManyExtensions [
 
             propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
               pkgs.cairo
-              pkgs.xlibsWrapper
             ];
 
             mesonFlags = [ "-Dpython=${if self.isPy3k then "python3" else "python"}" ];


### PR DESCRIPTION
`xlibsWrapper` was a transitional package to move from monolithic xorg package to modules. `nixpkgs` `python3Packages.pycairo` already removed `pkgs.xlibsWrapper`. This change follow the same change.

Bug: https://github.com/NixOS/nixpkgs/issues/194054
Closes: https://github.com/nix-community/poetry2nix/issues/863