### PR TITLE
ci: cancel duplicate CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   nixpkgs-fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR cancel existing GHA runs from single branch, so that when a new commit is pushed the currently running CI jobs for that branch/PR are cancelled.