### PR TITLE
feat: Show lock location in package errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -137,6 +137,7 @@ lib.makeScope pkgs.newScope (self: {
     { projectDir ? null
     , pyproject ? projectDir + "/pyproject.toml"
     , poetrylock ? projectDir + "/poetry.lock"
+    , poetrylockPos ? { file = toString poetrylock; line = 0; column = 0; }
     , overrides ? self.defaultPoetryOverrides
     , python ? pkgs.python3
     , pwd ? projectDir
@@ -207,6 +208,7 @@ lib.makeScope pkgs.newScope (self: {
                   value = self.mkPoetryDep (
                     pkgMeta // {
                       inherit pwd preferWheels;
+                      pos = poetrylockPos;
                       source = pkgMeta.source or null;
                       # Default to files from lock file version 2.0 and fall back to 1.1
                       files = pkgMeta.files or lockFiles.${normalizedName};

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -7,6 +7,7 @@
 }:
 { name
 , version
+, pos ? __curPos
 , files
 , source
 , dependencies ? { }
@@ -146,6 +147,8 @@ pythonPackages.callPackage
           depAttrs = lib.attrNames deps;
         in
         builtins.map (n: pythonPackages.${normalizePackageName n}) depAttrs;
+
+      inherit pos;
 
       meta = {
         broken = ! isCompatible (poetryLib.getPythonVersion python) python-versions;


### PR DESCRIPTION
Tested by temporarily setting `meta.broken = true;` in `mk-poetry-dep.nix`, and then

    $ nix-build tools -A env
    error: Package ‘python3.9-click-8.1.3’ in /home/user/h/poetry2nix/tools/poetry.lock:0 is marked as broken, refusing to evaluate.

       a) To temporarily allo[...]

As you can see, the location of the lock file is reported, which is especially useful in Nixpkgs, which contains multiple lockfiles.

This used to be just the location of a generic python builder, which is generally not what the user wants.

I've exposed the `poetrylockPos` variable as a parameter that callers may set. This is intended as a contingency more so than a feature that is useful to users. That's why I've decided not to document it, because it would just add noise. I could make it internal, a let binding, if you prefer.