### PR TITLE
fix: Use hatchling for filelock >=3.9.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -4974,10 +4974,22 @@
     "setuptools"
   ],
   "filelock": [
-    "setuptools",
-    "setuptools-scm",
-    "hatchling",
-    "hatch-vcs"
+    {
+      "buildSystem": "setuptools",
+      "until": "3.9.0"
+    },
+    {
+      "buildSystem": "setuptools-scm",
+      "until": "3.9.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "3.9.0"
+    },
+    {
+      "buildSystem": "hatch-vcs",
+      "from": "3.9.0"
+    }
   ],
   "filemagic": [
     "setuptools"


### PR DESCRIPTION
As per the [release log](https://github.com/tox-dev/py-filelock/releases/tag/3.9.0).

Should unblock https://github.com/linz/geostore/pull/2548.