### PR TITLE
Update filelock build systems

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -4955,7 +4955,9 @@
   ],
   "filelock": [
     "setuptools",
-    "setuptools-scm"
+    "setuptools-scm",
+    "hatchling",
+    "hatch-vcs"
   ],
   "filemagic": [
     "setuptools"


### PR DESCRIPTION
Hi!

`filelock` has [recently](https://github.com/tox-dev/py-filelock/commit/1cf8fcae4e688c60a078b1ec9286637141fb35bf#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R2-R3) switched to `hatchling` + `hatch-vcs`. This PR updates the corresponding override. I've kept setuptools and setuptools-scm in order to keep compatiblity with older versions (not sure if this is the recommended pattern for this).