### PR TITLE
Improve issue template: add syntax highlighting, don't make a bullet list

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -25,14 +25,14 @@ Community will happily help to find soulution and if needed create issue or pull
 Note that while these aren't strict requirements it will heavily increase your chances to get an issue fixed if you include more context that makes it possible to recreate the issue.
 -->
 
-- `default.nix`/`shell.nix`/`flake.nix`
+`default.nix`/`shell.nix`/`flake.nix`:
 ```
 ```
 
-- `pyproject.toml`
+`pyproject.toml`:
 ```
 ```
 
-- `poetry.lock`
+`poetry.lock`:
 ```
 ```

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -26,13 +26,13 @@ Note that while these aren't strict requirements it will heavily increase your c
 -->
 
 `default.nix`/`shell.nix`/`flake.nix`:
-```
+```nix
 ```
 
 `pyproject.toml`:
-```
+```toml
 ```
 
 `poetry.lock`:
-```
+```toml
 ```


### PR DESCRIPTION
- don't make a bullet list in section "Additional context"

  A bullet list would make sense if the code blocks would be part of the items. To make a code block part of a list item in Markdown, it would though have to be indentedwhich is either too laborious (when indenting all lines) or too confusing (when indenting only the opening line). If they aren't indented, they'd interrupt the list (thus effectively splitting it into 3 one-item lists) so let's instead just have the file names as prose-ish captions of the code blocks.

- add syntax highlighting

  We do know what languages we expect in the files we ask the issue author to provide in the "Additional context" section, so let's set up proper syntax highlighting for them.