### PR TITLE
build-systems: pytest-flake8

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13098,6 +13098,9 @@
   "pytest-fixture-config": [
     "setuptools"
   ],
+  "pytest-flake8": [
+    "setuptools"
+  ],
   "pytest-flakes": [
     "setuptools"
   ],


### PR DESCRIPTION
Make it possible to build projects depending on [pytest-flake8](https://github.com/tholo/pytest-flake8).

Tested with the following files:

- <details><summary><tt>shell.nix</tt> (click to expand)</summary>

  ```nix
  { pkgs ? import <nixpkgs> { }
  , poetry2nix ? import ~/dev/poetry2nix { }
  }:
  let
    myAppEnv = poetry2nix.mkPoetryEnv {
      projectDir = ./.;
      editablePackageSources = {
        my-app = ./src;
      };
    };
  in myAppEnv.env
  ```
  Where `~/dev/poetry2nix` is a clone of this git repo with this change.

  </details>
- <details><summary><tt>pyproject.toml</tt> (click to expand)</summary>

  ```toml
  [tool.poetry]
  name = "foo"
  version = "0.1.0"
  description = ""
  authors = ["Raphael Das Gupta <raphael.dasgupta@ost.ch>"]
  readme = "README.md"
  
  [tool.poetry.dependencies]
  python = "^3.10"
  
  [tool.poetry.group.dev.dependencies]
  pytest-flake8 = "^1.1.1"
  
  [build-system]
  requires = ["poetry-core"]
  build-backend = "poetry.core.masonry.api"
  ```

  </details>
- <details><summary><tt>poetry.lock</tt> (click to expand)</summary>

  ```toml
  # This file is automatically @generated by Poetry and should not be changed by hand.

  [[package]]
  name = "attrs"
  version = "22.2.0"
  description = "Classes Without Boilerplate"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  files = [
      {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
      {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
  ]

  [package.extras]
  cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
  dev = ["attrs[docs,tests]"]
  docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
  tests = ["attrs[tests-no-zope]", "zope.interface"]
  tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]

  [[package]]
  name = "colorama"
  version = "0.4.6"
  description = "Cross-platform colored terminal text."
  category = "dev"
  optional = false
  python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
  files = [
      {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
      {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
  ]

  [[package]]
  name = "exceptiongroup"
  version = "1.1.0"
  description = "Backport of PEP 654 (exception groups)"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  files = [
      {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
      {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
  ]

  [package.extras]
  test = ["pytest (>=6)"]

  [[package]]
  name = "flake8"
  version = "6.0.0"
  description = "the modular source code checker: pep8 pyflakes and co"
  category = "dev"
  optional = false
  python-versions = ">=3.8.1"
  files = [
      {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
      {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
  ]

  [package.dependencies]
  mccabe = ">=0.7.0,<0.8.0"
  pycodestyle = ">=2.10.0,<2.11.0"
  pyflakes = ">=3.0.0,<3.1.0"

  [[package]]
  name = "iniconfig"
  version = "1.1.1"
  description = "iniconfig: brain-dead simple config-ini parsing"
  category = "dev"
  optional = false
  python-versions = "*"
  files = [
      {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
      {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
  ]

  [[package]]
  name = "mccabe"
  version = "0.7.0"
  description = "McCabe checker, plugin for flake8"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  files = [
      {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
      {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
  ]

  [[package]]
  name = "packaging"
  version = "22.0"
  description = "Core utilities for Python packages"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  files = [
      {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
      {file = "packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
  ]

  [[package]]
  name = "pluggy"
  version = "1.0.0"
  description = "plugin and hook calling mechanisms for python"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  files = [
      {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
      {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
  ]

  [package.extras]
  dev = ["pre-commit", "tox"]
  testing = ["pytest", "pytest-benchmark"]

  [[package]]
  name = "pycodestyle"
  version = "2.10.0"
  description = "Python style guide checker"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  files = [
      {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
      {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
  ]

  [[package]]
  name = "pyflakes"
  version = "3.0.1"
  description = "passive checker of Python programs"
  category = "dev"
  optional = false
  python-versions = ">=3.6"
  files = [
      {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
      {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
  ]

  [[package]]
  name = "pytest"
  version = "7.2.0"
  description = "pytest: simple powerful testing with Python"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  files = [
      {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
      {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
  ]

  [package.dependencies]
  attrs = ">=19.2.0"
  colorama = {version = "*", markers = "sys_platform == \"win32\""}
  exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
  iniconfig = "*"
  packaging = "*"
  pluggy = ">=0.12,<2.0"
  tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}

  [package.extras]
  testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]

  [[package]]
  name = "pytest-flake8"
  version = "1.1.1"
  description = "pytest plugin to check FLAKE8 requirements"
  category = "dev"
  optional = false
  python-versions = "*"
  files = [
      {file = "pytest-flake8-1.1.1.tar.gz", hash = "sha256:ba4f243de3cb4c2486ed9e70752c80dd4b636f7ccb27d4eba763c35ed0cd316e"},
      {file = "pytest_flake8-1.1.1-py2.py3-none-any.whl", hash = "sha256:e0661a786f8cbf976c185f706fdaf5d6df0b1667c3bcff8e823ba263618627e7"},
  ]

  [package.dependencies]
  flake8 = ">=4.0"
  pytest = ">=7.0"

  [[package]]
  name = "tomli"
  version = "2.0.1"
  description = "A lil' TOML parser"
  category = "dev"
  optional = false
  python-versions = ">=3.7"
  files = [
      {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
      {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
  ]

  [metadata]
  lock-version = "2.0"
  python-versions = "^3.10"
  content-hash = "08fa0e2a5523c90c8ff3945e5190a2d0b28441cc5007b77b554505b0f650757c"
  ```

  </details>

by running
```bash
nix-shell --command 'pytest --flake8'
```