### PR TITLE
fix: Use setuptools-scm for python-ulid

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13853,7 +13853,8 @@
     "setuptools"
   ],
   "python-ulid": [
-    "setuptools"
+    "setuptools",
+    "setuptools-scm"
   ],
   "python-unshare": [
     "setuptools"


### PR DESCRIPTION
Closes #921.