### PR TITLE
flake: define packages without re-importing nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,17 +18,17 @@
       defaultTemplate = templates.app;
 
     } // (flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ self.overlay ];
-        };
-      in
       rec {
-        packages = {
-          inherit (pkgs) poetry;
-          poetry2nix = pkgs.poetry2nix.cli;
-        };
+        packages =
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            poetry = pkgs.callPackage ./pkgs/poetry { python = pkgs.python3; };
+            poetry2nix = import ./default.nix { inherit pkgs poetry; };
+          in
+          {
+            inherit poetry;
+            poetry2nix = poetry2nix.cli;
+          };
 
         defaultPackage = packages.poetry2nix;
 


### PR DESCRIPTION
This avoids re-importing nixpkgs and thereby allocating a lot of additional memory. Instead pkgs.callPackage is used directly without creating a new nixpkgs instance.

Closes #652.

Replaces #868 which does not make sense at the moment, since it uses poetry2nix from nixpkgs instead of from the repo itself.