### PR TITLE
flake: expose default.nix as outputs.lib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,13 +18,13 @@
       defaultTemplate = templates.app;
 
     } // (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        poetry = pkgs.callPackage ./pkgs/poetry { python = pkgs.python3; };
+        poetry2nix = import ./default.nix { inherit pkgs poetry; };
+      in
       rec {
         packages =
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            poetry = pkgs.callPackage ./pkgs/poetry { python = pkgs.python3; };
-            poetry2nix = import ./default.nix { inherit pkgs poetry; };
-          in
           {
             inherit poetry;
             poetry2nix = poetry2nix.cli;
@@ -38,5 +38,7 @@
         };
 
         defaultApp = apps.poetry2nix;
+
+        lib = poetry2nix;
       }));
 }


### PR DESCRIPTION
Currently using poetry2nix functions requires using the Nixpkgs overlay.

This exposes the functions on the flake outputs, so they can be used like this:

~~~nix
{
  inputs = {
    poetry2nix.url = "github:nix-community/poetry2nix/e74e60eb82e35e13f181125097625405bd7a1a39";
  };
  
  outputs = {self, poetry2nix}: {
    packages.x86_64-linux.default = poetry2nix.lib.x86_64-linux.mkPoetryApplication {
      projectDir = ./.;
    };
  };
}
~~~