### PR TITLE
fix: fix shapely wheel build with newer versions of nixpkgs

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2227,7 +2227,7 @@ lib.composeManyExtensions [
       shapely = super.shapely.overridePythonAttrs (
         old: {
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.geos ];
-          inherit (pkgs.python3.pkgs.shapely) GEOS_LIBRARY_PATH;
+          GEOS_LIBRARY_PATH = pkgs.python3.pkgs.shapely.GEOS_LIBRARY_PATH or null;
 
           GEOS_LIBC = lib.optionalString (!stdenv.isDarwin) "${lib.getLib stdenv.cc.libc}/lib/libc${stdenv.hostPlatform.extensions.sharedLibrary}.6";
 


### PR DESCRIPTION
This PR fixes an issue with wheel builds of shapely using newer versions of nixpkgs which seem to lack `GEOS_LIBRARY_PATH`.