### PR TITLE
fix: wheel url parsing

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -185,6 +185,7 @@ pythonPackages.callPackage
           builtins.fetchTarball
             {
               inherit (source) url;
+              sha256 = fileInfo.hash;
             }
         else if isDirectory then
           (poetryLib.cleanPythonSources { src = localDepPath; })

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -46,6 +46,7 @@ pythonPackages.callPackage
       isSource = source != null;
       isGit = isSource && source.type == "git";
       isUrl = isSource && source.type == "url";
+      isWheelUrl = isSource && source.type == "url" && lib.strings.hasSuffix ".whl" source.url;
       isDirectory = isSource && source.type == "directory";
       isFile = isSource && source.type == "file";
       isLegacy = isSource && source.type == "legacy";
@@ -94,7 +95,7 @@ pythonPackages.callPackage
             else (builtins.elemAt (lib.strings.splitString "-" name) 2);
         };
 
-      format = if isDirectory || isGit || isUrl then "pyproject" else fileInfo.format;
+      format = if isWheelUrl then "wheel" else if isDirectory || isGit || isUrl then "pyproject" else fileInfo.format;
 
       hooks = python.pkgs.callPackage ./hooks { };
     in
@@ -181,6 +182,12 @@ pythonPackages.callPackage
               }
             ))
           )
+        else if isWheelUrl then
+          builtins.fetchurl
+            {
+              inherit (source) url;
+              sha256 = fileInfo.hash;
+            }
         else if isUrl then
           builtins.fetchTarball
             {


### PR DESCRIPTION
Currently (as far as I can tell) all url dependency specs are treated as source tarballs, and specifying wheel urls fails. 
I need to add wheels manually from a non pypi source (https://data.pyg.org/whl/) which gave an error when trying to build it -  
a) didn't use the hash of the wheel, so I had to use --impure and 
b) thought that the wheel is a tarball, not a zip
c) didn't know how to use the wheel format if the url points to a wheel

This PR addresses those issues