### PR TITLE
Updates to pydocstyle and selenium

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -15296,9 +15296,6 @@
   "selectors2": [
     "setuptools"
   ],
-  "selenium": [
-    "setuptools"
-  ],
   "selinux": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11579,7 +11579,14 @@
     "setuptools"
   ],
   "pydocstyle": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "6.2.0"
+    },
+    {
+      "buildSystem": "poetry-core",
+      "from": "6.2.0"
+    }
   ],
   "pydocumentdb": [
     "setuptools"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2224,6 +2224,19 @@ lib.composeManyExtensions [
         '';
       });
 
+      selenium =
+        let
+          v4orLater = lib.versionAtLeast super.selenium.version "4";
+          selenium = super.selenium.override {
+            # Selenium >=4 is built with Bazel
+            preferWheel = v4orLater;
+          };
+        in
+        selenium.overridePythonAttrs (old: {
+          # Selenium <4 can be installed from sources, with setuptools
+          buildInputs = old.buildInputs ++ (lib.optionals (!v4orLater) [ self.setuptools ]);
+        });
+
       shapely = super.shapely.overridePythonAttrs (
         old: {
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.geos ];


### PR DESCRIPTION
fix: pydocstyle >= 6.2.0 build system 

[Selenium 4.0 uses Bazel to build python code][1]. Let's use the wheel to make it easier.

The override is split in two due to https://github.com/nix-community/poetry2nix/pull/948.

[1]: https://github.com/SeleniumHQ/selenium/blob/3ad153b16804695fb0448b43940b703b8022f45c/py/CHANGES#L368