### PR TITLE
feat: Configure Dependabot for all poetry.lock files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/pkgs"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,287 @@
 version: 2
 updates:
-  # Auto-update the Poetry package, but not tests
   - package-ecosystem: "pip"
     directory: "/pkgs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/aiopath"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/ansible-molecule"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/assorted-pkgs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/awscli"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/bcrypt"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/canonical-module-names"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/cffi-pandas-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/closure-size"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/common-pkgs-1"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/common-pkgs-2"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/composable-defaults"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/dependency-environment"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/dependency-groups"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/duckdb-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/editable"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/editable-egg"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/eggs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/env"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/extended-cross"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/extras"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/fancycompleter-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/file-src-deps"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/file-src-deps-level2"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/file-wheel-deps"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/file-wheel-deps-level2"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/fiona-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/gdal"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/git-deps"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/git-deps-1_2_0"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/git-deps-pinned"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/in-list"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/jq"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/legacy"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/manylinux"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/markupsafe2"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/missing-iswheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/mkdocstrings-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/mk-poetry-packages"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/nbconvert-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/operators"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/override-default-support"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/override-support"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/path-deps"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/path-deps-develop"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/path-deps-level2"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/pendulum"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/pep600"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/prefer-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/prefer-wheels"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/pyarrow-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/pyqt5"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/pytest-randomly"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/rasterio"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/scientific"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/scipy1_9"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/setuptools"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/shapely"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/shapely-wheel"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/source-filter"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/test-extras"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/test-group"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/test-no-extras"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/trivial"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/trivial-cross"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/trivial-poetry-1_2_0"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/utf8-pyproject"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/uwsgi"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/wandb"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/watchfiles"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tests/wheel-wheel"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"


### PR DESCRIPTION
Some of these will probably have to be tweaked because they are tailored to specific versions of a package. This can be done by [ignoring](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) the relevant package. That way, the test can still get updated versions of any other packages, so it stays relevant as long as possible. An alternative approach is to not ignore anything, but to create a new test whenever a Dependabot update breaks an existing test.

Other thoughts:

- This will result in a large number of Dependabot PRs, at least at first. It might be worth upping or removing the [limit on open PRs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit), at least to begin with.
- Some packages might be updated very often, like semi-daily, and could create a fair bit of overhead to just deal with the PRs. Two options:
   - Reduce the update frequency to weekly or monthly, at the risk of missing a broken package for a long-ish time. Not recommended since there are probably many poetry2nix users who update on a daily basis.
   - Configure Kodiak to [merge passing Dependabot PRs automatically](https://kodiakhq.com/docs/config-reference#mergeautomerge_dependenciesversions).

Generated with the following code:

```bash
git ls-files '**/poetry.lock' | xargs dirname | sort | while read dir; do printf '  - package-ecosystem: "pip"
    directory: "/%s"
    schedule:
      interval: "daily"
' "$dir"; done >> .github/dependabot.yml 
```

Closes #932.

(I might be unavailable for comment until ~January 28th.)