### PR TITLE
Link include and share folders in pybind11 to top-level

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2133,6 +2133,11 @@ lib.composeManyExtensions [
             "-DPYBIND11_TEST=off"
           ];
           doCheck = false; # Circular test dependency
+
+          # Link include and share so it can be used by packages that use pybind11 through cmake
+          postInstall = ''
+            ln -s $out/${self.python.sitePackages}/pybind11/{include,share} $out/
+          '';
         }
       );
 


### PR DESCRIPTION
This makes sure that share and include exist at $out so the pybind11 headers and cmake libraries can be found by cmake.