### PR TITLE
Add setuptools build dependency to ligo-segments

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7988,6 +7988,9 @@
   "lightwave2": [
     "setuptools"
   ],
+  "ligo-segments": [
+    "setuptools"
+  ],
   "lima": [
     "setuptools"
   ],


### PR DESCRIPTION
I'm not sure if there's a typical format for these PRs, but this adds setuptools as a build dependency to the ligo-segments package to fix builds that depend on that package.