### PR TITLE
fix: add `nativeCheckInputs` for newer nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -72,6 +72,9 @@ let
           rawDeps
         else
           rawRequiredDeps // lib.getAttrs desiredExtrasDeps rawDeps;
+      checkInputs' = getDeps (pyProject.tool.poetry."dev-dependencies" or { })  # <poetry-1.2.0
+        # >=poetry-1.2.0 dependency groups
+        ++ lib.flatten (map (g: getDeps (pyProject.tool.poetry.group.${g}.dependencies or { })) checkGroups);
     in
     {
       buildInputs = mkInput "buildInputs" (if includeBuildSystem then buildSystemPkgs else [ ]);
@@ -84,11 +87,8 @@ let
         )
       );
       nativeBuildInputs = mkInput "nativeBuildInputs" [ ];
-      checkInputs = mkInput "checkInputs" (
-        getDeps (pyProject.tool.poetry."dev-dependencies" or { })  # <poetry-1.2.0
-        # >=poetry-1.2.0 dependency groups
-        ++ lib.flatten (map (g: getDeps (pyProject.tool.poetry.group.${g}.dependencies or { })) checkGroups)
-      );
+      checkInputs = mkInput "checkInputs" checkInputs';
+      nativeCheckInputs = mkInput "nativeCheckInputs" checkInputs';
     };
 
 


### PR DESCRIPTION
This PR adds support for nativeCheckInputs, which appears to be the only supported way to introduce test dependencies in nixos-unstable-small as of https://github.com/NixOS/nixpkgs/commit/33afbf39f6f2a6b37e99f070ba7d17a28c416d02.
