### PR TITLE
feat: Verify that build systems are sorted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  sort-build-systems:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: actions/checkout@v3
+    - name: Check format
+      run: nix-shell --packages jq --pure --run 'diff overrides/build-systems.json <(jq --raw-output --sort-keys < overrides/build-systems.json)'
+
   nixpkgs-fmt:
     runs-on: ubuntu-latest
     steps:

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5093,9 +5093,6 @@
   "flake8-plugin-utils": [
     "poetry"
   ],
-  "flake8-pytest-style": [
-    "poetry-core"
-  ],
   "flake8-polyfill": [
     "setuptools"
   ],
@@ -5104,6 +5101,9 @@
   ],
   "flake8-pyprojecttoml": [
     "setuptools"
+  ],
+  "flake8-pytest-style": [
+    "poetry-core"
   ],
   "flake8-simplify": [
     "setuptools"
@@ -18635,6 +18635,9 @@
   "zipstream-ng": [
     "setuptools"
   ],
+  "zk": [
+    "setuptools"
+  ],
   "zm-py": [
     "setuptools"
   ],
@@ -18724,9 +18727,6 @@
     "setuptools"
   ],
   "zulip": [
-    "setuptools"
-  ],
-  "zk": [
     "setuptools"
   ],
   "zwave-js-server-python": [


### PR DESCRIPTION
Uses a specific runner version (rather than "ubuntu-latest") to avoid replication issues when GitHub runners are updated.