### PR TITLE
feat: autofix version for all packages that use setuptools-scm

### DIFF
--- a/hooks/pip-build-hook.sh
+++ b/hooks/pip-build-hook.sh
@@ -5,7 +5,7 @@ pipBuildPhase() {
     echo "Executing pipBuildPhase"
     runHook preBuild
 
-    if [ -z "$SETUPTOOLS_SCM_PRETEND_VERSION" ] && echo "$buildInputs" | grep setuptools-scm; then
+    if [ -z "$SETUPTOOLS_SCM_PRETEND_VERSION" ] && echo "$buildInputs" | grep -E 'setuptools-scm|hatch-vcs'; then
         export SETUPTOOLS_SCM_PRETEND_VERSION="$version"
     fi
 

--- a/hooks/pip-build-hook.sh
+++ b/hooks/pip-build-hook.sh
@@ -5,6 +5,10 @@ pipBuildPhase() {
     echo "Executing pipBuildPhase"
     runHook preBuild
 
+    if [ -z "$SETUPTOOLS_SCM_PRETEND_VERSION" ] && echo "$buildInputs" | grep setuptools-scm; then
+        export SETUPTOOLS_SCM_PRETEND_VERSION="$version"
+    fi
+
     mkdir -p dist
     echo "Creating a wheel..."
     @pythonInterpreter@ -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2747,10 +2747,6 @@ lib.composeManyExtensions [
         '';
       });
 
-      pyyaml-include = super.pyyaml-include.overridePythonAttrs (old: {
-        SETUPTOOLS_SCM_PRETEND_VERSION = old.version;
-      });
-
       selinux = super.selinux.overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools-scm-git-archive ];
       });


### PR DESCRIPTION
Building a package that has setuptools-scm usually fails if it doesn't define an override like the one I'm removing in `pyyaml-include`.

Or sometimes it works, but packages that depend on it don't work because they define some lower bound of the dependency, but the dependency doesn't have an appropriate version defined.

With this simple fix, all packages that use setuptools-scm will include the `SETUPTOOLS_SCM_PRETEND_VERSION` to let them inherit the appropriate version.

@moduon MT-1075