### PR TITLE
overrides: automat: only add m2r to inputs for older versions

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -99,7 +99,7 @@ lib.composeManyExtensions [
 
     {
       automat = super.automat.overridePythonAttrs (
-        old: {
+        old: lib.optionalAttrs (lib.versionOlder old.version "22.10.0") {
           propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.m2r ];
         }
       );


### PR DESCRIPTION
Newer versions of automat do not depend on m2r anymore [1]. Because of this m2r might not end up being in poetry.lock along with automat, so "self.m2r" ends up refering to the nixpkgs pythonPackages.m2r. That package happens to be marked as broken in some conditions.