### PR TITLE
build-systems: add bencode-py

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1873,6 +1873,9 @@
   "bellows": [
     "setuptools"
   ],
+  "bencode-py": [
+    "setuptools"
+  ],
   "beniget": [
     "setuptools"
   ],


### PR DESCRIPTION
I'm unable to explain why the CI is failing.
The parse error happens on a line that doesn't seem related to the lines I'm changing here.