### PR TITLE
added override for python-hcl2 build system

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13587,6 +13587,9 @@
     "poetry-core",
     "setuptools"
   ],
+  "python-hcl2": [
+    "setuptools"
+  ],
   "python-heatclient": [
     "pbr",
     "setuptools"


### PR DESCRIPTION
Should fix ModuleNotFoundError where setuptools was missing