### PR TITLE
docs: Testing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ To run specific tests, add `--attr NAME` to the `nix-build` command above. For e
 nix-build --attr bcrypt --attr jq --keep-going --show-trace tests/default.nix
 ```
 
+To test with a specific channel:
+
+```bash
+nix-build --expr 'with import <unstable> {}; callPackage ./tests/default.nix {}'
+```
+
 ## Contact
 We have a Matrix room at [#poetry2nix:blad.is](https://matrix.to/#/#poetry2nix:blad.is).
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ Contributions to this project are welcome in the form of GitHub PRs. Please cons
 nix-build --keep-going --show-trace tests/default.nix
 ```
 
+To list test names:
+
+```bash
+nix eval --impure --expr 'let pkgs = import <nixpkgs> {}; in pkgs.lib.attrNames (import ./tests/default.nix {})'
+```
+
 ## Contact
 We have a Matrix room at [#poetry2nix:blad.is](https://matrix.to/#/#poetry2nix:blad.is).
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ To list test names:
 nix eval --impure --expr 'let pkgs = import <nixpkgs> {}; in pkgs.lib.attrNames (import ./tests/default.nix {})'
 ```
 
+To run specific tests, add `--attr NAME` to the `nix-build` command above. For example, to run the `bcrypt` and `jq` tests:
+
+```bash
+nix-build --attr bcrypt --attr jq --keep-going --show-trace tests/default.nix
+```
+
 ## Contact
 We have a Matrix room at [#poetry2nix:blad.is](https://matrix.to/#/#poetry2nix:blad.is).
 


### PR DESCRIPTION
Hopefully these can be simplified a bit - the `callPackage` syntax is very different from the default channel syntax.