### PR TITLE
build: Bump nixpkgs

### DIFF
--- a/hooks/default.nix
+++ b/hooks/default.nix
@@ -18,7 +18,7 @@ let
         makeSetupHook
           {
             name = "remove-path-dependencies.sh";
-            deps = [ ];
+            propagatedBuildInputs = [ ];
             substitutions = {
               # NOTE: We have to use a non-overlayed Python here because otherwise we run into an infinite recursion
               # because building of tomlkit and its dependencies also use these hooks.
@@ -50,7 +50,7 @@ in
       makeSetupHook
         {
           name = "pip-build-hook.sh";
-          deps = [ pip wheel ];
+          propagatedBuildInputs = [ pip wheel ];
           substitutions = {
             inherit pythonInterpreter pythonSitePackages;
           };
@@ -64,7 +64,7 @@ in
       makeSetupHook
         {
           name = "fixup-hook.sh";
-          deps = [ ];
+          propagatedBuildInputs = [ ];
           substitutions = {
             inherit pythonSitePackages;
             filenames = builtins.concatStringsSep " " [
@@ -84,7 +84,7 @@ in
       makeSetupHook
         {
           name = "wheel-unpack-hook.sh";
-          deps = [ ];
+          propagatedBuildInputs = [ ];
         } ./wheel-unpack-hook.sh
     )
     { };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixos-unstable",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f493a530feec7358f23d3680416b123717bdf62",
-        "sha256": "02pn2w7az8pxryqggx69m2fkrsw1qxidiz33z52vj4d5snc7lhd9",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "sha256": "1fv3x7lql7ypiv7zb7qi08fbjjdlxwhhgrabmqli1m38ixs71ffx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6f493a530feec7358f23d3680416b123717bdf62.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7f5639fa3b68054ca0b062866dc62b22c3f11505.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
With `niv update`, using the unstable branch.

Requires some workaround for

> SyntaxError: future feature annotations is not defined

(maybe https://github.com/NixOS/nixpkgs/pull/218399?) and #1014 to avoid

> error: attribute 'TESTING_FOOBAR' missing