### PR TITLE
chore: Remove Python 2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,6 @@ jobs:
     - name: Check format
       run: nix-shell --arg packages 'pkgs:[ pkgs.nixpkgs-fmt ]' --run 'nixpkgs-fmt --check .'
 
-  py2-compat:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cachix/install-nix-action@v19
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: actions/checkout@v3
-    - uses: cachix/cachix-action@v12
-      with:
-        name: poetry2nix
-        signingKey: "VhaWuN3IyJVpWg+aZvTocVB+W8ziZKKRGLKR53Pkld3YRZxYOUfXZf0fvqF+LkqVW0eA60trVd5vsqNONpX9Hw=="
-    - name: Check format
-      run: nix-shell --arg packages 'pkgs:[ pkgs.p2nix-tools.py2-astparse ]' --run 'git ls-files | grep -Pv "^tools" | grep -P "\.py$" | xargs py2-astparse'
-
   black-fmt:
     runs-on: ubuntu-latest
     steps:

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -15839,14 +15839,14 @@
     "setuptools",
     "setuptools-scm"
   ],
-  "singledispatch": [
-    "setuptools"
-  ],
   "single-source": [
     "poetry-core"
   ],
   "single-version": [
     "poetry-core",
+    "setuptools"
+  ],
+  "singledispatch": [
     "setuptools"
   ],
   "siobrultech-protocols": [

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
 { packages ? pkgs: [
     pkgs.p2nix-tools.env
-    pkgs.p2nix-tools.py2-astparse
     pkgs.p2nix-tools.flamegraph
     pkgs.nixpkgs-fmt
     pkgs.poetry

--- a/tools/default.nix
+++ b/tools/default.nix
@@ -40,20 +40,4 @@ in
     projectDir = ./.;
   };
 
-  py2-astparse = pkgs.writeScriptBin "py2-astparse" ''
-    #!${pkgs.python2.interpreter}
-    # Used as a smoke test for Python2 compatibility in Python files
-    import sys
-    import ast
-
-    if __name__ == "__main__":
-        with open(sys.argv[1]) as f:
-            try:
-                ast.parse(f.read())
-            except Exception as e:
-                sys.stderr.write("Error parsing '{}':\n".format(sys.argv[1]))
-                sys.stderr.flush()
-                raise
-  '';
-
 }


### PR DESCRIPTION
From the build:

> Package ‘python-2.7.18.6’ in
> /nix/store/n5hj62lgkwvz3gqnp4l4nxzjnadh7y54-source/pkgs/development/interpreters/python/cpython/2.7/default.nix:330
> is marked as insecure, refusing to evaluate.

and

> Python 2.7 has reached its end of life after 2020-01-01. See
> https://www.python.org/doc/sunset-python-2/.

Necessary to bump nixpkgs
<https://github.com/nix-community/poetry2nix/pull/996>.