### PR TITLE
fix: Use new `overridePythonAttrs`

### DIFF
--- a/tests/override-default-support/default.nix
+++ b/tests/override-default-support/default.nix
@@ -9,7 +9,7 @@ let
       ((
         poetry2nix.defaultPoetryOverrides.overrideOverlay (
           self: super: {
-            alembic = super.alembic.overrideAttrs (
+            alembic = super.alembic.overridePythonAttrs (
               old: {
                 TESTING_FOOBAR = 42;
               }

--- a/tests/override-support/default.nix
+++ b/tests/override-support/default.nix
@@ -7,7 +7,7 @@ let
     pyproject = ./pyproject.toml;
     overrides = poetry2nix.overrides.withDefaults (
       self: super: {
-        alembic = super.alembic.overrideAttrs (
+        alembic = super.alembic.overridePythonAttrs (
           old: {
             TESTING_FOOBAR = 42;
           }


### PR DESCRIPTION
Necessary to override package attributes in newer nixpkgs.