### PR TITLE
numpy: Set NPY_NUM_BUILD_JOBS for parallel build

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1358,6 +1358,9 @@ lib.composeManyExtensions [
           preBuild = ''
             ln -s ${cfg} site.cfg
           '';
+          preConfigure = ''
+            export NPY_NUM_BUILD_JOBS=$NIX_BUILD_CORES
+          '';
           passthru = old.passthru // {
             blas = blas;
             inherit blasImplementation cfg;


### PR DESCRIPTION
As documented https://numpy.org/doc/stable/user/building.html, this enable parallel build for numpy