### PR TITLE
Update build-systems (and update CI install-nix-action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   sort-build-systems:
     runs-on: ubuntu-22.04
     steps:
-    - uses: cachix/install-nix-action@v19
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
   nixpkgs-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v19
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
   black-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v19
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v19
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - id: set-matrix
@@ -65,7 +65,7 @@ jobs:
       matrix: ${{fromJSON(needs.matrix_generate.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v19
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -78,7 +78,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v19
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -4184,7 +4184,13 @@
   "django-rest-polymorphic": [
     "setuptools"
   ],
+  "django-rest-swagger": [
+    "setuptools"
+  ],
   "django-reversion": [
+    "setuptools"
+  ],
+  "django-rosetta": [
     "setuptools"
   ],
   "django-rq": [
@@ -9982,6 +9988,9 @@
     "setuptools"
   ],
   "openant": [
+    "setuptools"
+  ],
+  "openapi-codec": [
     "setuptools"
   ],
   "openapi-core": [
@@ -17904,6 +17913,9 @@
     "setuptools"
   ],
   "unify": [
+    "setuptools"
+  ],
+  "unipath": [
     "setuptools"
   ],
   "units": [


### PR DESCRIPTION
Add build system for:
- django-rest-swagger
- django-rosetta
- openapi-codec
- unipath

Also, Nix 2.14 broke cachix/install-nix-action, see:
https://github.com/cachix/install-nix-action/pull/163