### PR TITLE
Add overrides for hikari and hikari-lightbulb

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -793,6 +793,12 @@ lib.composeManyExtensions [
           buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
         }
       );
+
+      hikari-lightbulb = super.hikari-lightbulb.overrideAttrs (
+        old: {
+          buildInputs = (old.buildInputs or []) ++ [self.setuptools];
+        }
+      );
       
       horovod = super.horovod.overridePythonAttrs (
         old: {

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -796,10 +796,10 @@ lib.composeManyExtensions [
 
       hikari-lightbulb = super.hikari-lightbulb.overrideAttrs (
         old: {
-          buildInputs = (old.buildInputs or []) ++ [self.setuptools];
+          buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
         }
       );
-      
+
       horovod = super.horovod.overridePythonAttrs (
         old: {
           propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pkgs.mpi ];

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -788,6 +788,12 @@ lib.composeManyExtensions [
         }
       );
 
+      hikari = super.hikari.overrideAttrs (
+        old: {
+          buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
+        }
+      );
+      
       horovod = super.horovod.overridePythonAttrs (
         old: {
           propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pkgs.mpi ];


### PR DESCRIPTION
`hikari` is a library to write discord bots in python and `hikari-lightbulb` is a command handler for `hikari`. Both of these can be used in poetry2nix with some minor tweaks