### PR TITLE
fix: Use new output syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           set -euo pipefail
 
           matrix="$(nix-instantiate --eval --json --expr 'builtins.attrNames (import ./tests {})' | jq -rcM '{attr: .}')"
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   builds-linux:
     needs: matrix_generate


### PR DESCRIPTION
See
<https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/> and
<https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files>.

The deprecated syntax will start breaking "1st June 2023".