### PR TITLE
Add the build system updates required for python-dxf

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13847,6 +13847,9 @@
   "python-dotenv": [
     "setuptools"
   ],
+  "python-dxf": [
+    "setuptools"
+  ],
   "python-ecobee-api": [
     "setuptools"
   ],
@@ -18614,6 +18617,9 @@
     "setuptools"
   ],
   "wurlitzer": [
+    "setuptools"
+  ],
+  "www-authenticate": [
     "setuptools"
   ],
   "wxpython-4-0": [

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -383,6 +383,7 @@ lib.composeManyExtensions [
             "38.0.3" = "sha256-lzHLW1N4hZj+nn08NZiPVM/X+SEcIsuZDjEOy0OOkSc=";
             "38.0.4" = "sha256-BN0kOblUwgHj5QBf52RY2Jx0nBn03lwoN1O5PEohbwY=";
             "39.0.0" = "sha256-clorC0NtGukpE3DnZ84MSdGhJN+qC89DZPITZFuL01Q=";
+            "39.0.2" = "sha256-Admz48/GS2t8diz611Ciin1HKQEyMDEwHxTpJ5tZ1ZA=";
           }.${version} or (
             lib.warn "Unknown cryptography version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
Add the build system updates required for python-dxf. This adds `python-dxf` itself, `www-authenticate` and a new release of `cryptography`.