### PR TITLE
fix: aws-sso-util needs Poetry

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1465,6 +1465,9 @@
   "aws-sam-translator": [
     "setuptools"
   ],
+  "aws-sso-lib": [
+    "poetry"
+  ],
   "aws-xray-sdk": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1468,6 +1468,9 @@
   "aws-sso-lib": [
     "poetry"
   ],
+  "aws-sso-util": [
+    "poetry"
+  ],
   "aws-xray-sdk": [
     "setuptools"
   ],


### PR DESCRIPTION
PiPi package `aws-sso-utils` requires Poetry

Tested and working on my branch

pyproject.toml:

```toml
[tool.poetry]
name = "resource-accounts"
version = "0.1.0"
description = "IaC for resource accounts"
authors = ["Ariel Richtman <ariel.richtman@silverrailtech.com>"]

[tool.poetry.dependencies]
python = "^3.10"
diagrams = "*"
aws-sso-util = "*"

[tool.poetry.group.dev.dependencies]
pre-commit = "*"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```

flake.nix

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";

    utils = {
      url = github:numtide/flake-utils;
    };
    poetry2nix = {
      # url = "github:nix-community/poetry2nix";
      url = "github:arichtman/poetry2nix/aws-sso-util-override";
      inputs.nixpkgs.follows = "nixpkgs";
  };
  };
  outputs = { nixpkgs, utils, self, poetry2nix, ... }:
    utils.lib.eachDefaultSystem (system:
      let
        inherit (poetry2nix.legacyPackages.${system}) mkPoetryEnv;
        pkgs = import nixpkgs {
            inherit system;
          };
          poetryEnv = mkPoetryEnv {
            projectDir = ./.;
          };
      in {
        devShell = with pkgs; mkShell {
          buildInputs = [ poetryEnv terraform terragrunt awscli2 ];
            shellHook = ''
            pre-commit install --install-hooks
          '';
      };
    }
  );
}
```