### PR TITLE
Add build system for fastapi-utils

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5207,6 +5207,9 @@
   "fastapi-restful": [
     "poetry"
   ],
+  "fastapi-utils": [
+    "poetry"
+  ],
   "fastavro": [
     "cython",
     "setuptools"


### PR DESCRIPTION
- [x] Add new entry to `overrides/build-systems.json`
- [x] Add simple test to validate successful install (`tests/fastapi-utils/*`)
- [x] Run locally to validate successful build