### PR TITLE
Update default.nix

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1612,6 +1612,10 @@ lib.composeManyExtensions [
         }
       );
 
+      pip-requirements-parser = super.pip-requirements-parser.overridePythonAttrs (old: {
+        dontConfigure = true;
+      });
+
       pluralizer = super.pluralizer.overridePythonAttrs (old: {
         preBuild = ''
           export PYPI_VERSION="${old.version}"


### PR DESCRIPTION
Don't configure `pip-requirements-parser`.

Fixes the following error:
```
error: builder for '/nix/store/zxzy82bvkxim44ab4p0nl7qdxlbwqbah-python3.10-pip-requirements-parser-32.0.1.drv' failed with exit code 127;
       last 10 log lines:
       > source root is pip-requirements-parser-32.0.1
       > setting SOURCE_DATE_EPOCH to timestamp 1671636260 of file pip-requirements-parser-32.0.1/setup.cfg
       > patching sources
       > Removing path dependencies
       > Finished removing path dependencies
       > Removing git dependencies
       > Finished removing git dependencies
       > configuring
       > configure flags: --prefix=/nix/store/3amsl67vbg6y28clkhk889hbcknnp3rr-python3.10-pip-requirements-parser-32.0.1
       > /nix/store/pw17yc3mwmsci4jygwalj8ppg0drz31v-stdenv-linux/setup: line 1289: ./configure: cannot execute: required file not found
```