### PR TITLE
fix: gitlint needs hatch-vcs

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -6143,7 +6143,18 @@
     "setuptools"
   ],
   "gitlint": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "0.19"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "0.19"
+    },
+    {
+      "buildSystem": "hatch-vcs",
+      "from": "0.19"
+    }
   ],
   "gitlint-core": [
     {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -138,7 +138,7 @@ builtins.removeAttrs
   affine = callTest ./affine { };
   affine-pre-2-4 = callTest ./affine-pre-2-4 { };
   gdal = callTest ./gdal { };
-  gitlint-core = callTest ./gitlint-core { };
+  gitlint = callTest ./gitlint { };
   jupyter-ydoc = callTest ./jupyter-ydoc { };
   mutmut = callTest ./mutmut { };
   rasterio = callTest ./rasterio { };

--- a/tests/gitlint/default.nix
+++ b/tests/gitlint/default.nix
@@ -4,6 +4,6 @@ let
     projectDir = ./.;
   };
 in
-runCommand "gitlint-core-test" { } ''
+runCommand "gitlint-test" { } ''
   ${env}/bin/gitlint --version > $out
 ''

--- a/tests/gitlint/poetry.lock
+++ b/tests/gitlint/poetry.lock
@@ -43,6 +43,21 @@ files = [
 ]
 
 [[package]]
+name = "gitlint"
+version = "0.19.1"
+description = "Git commit message linter written in python, checks your commit messages for style."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "gitlint-0.19.1-py3-none-any.whl", hash = "sha256:26bb085959148d99fbbc178b4e56fda6c3edd7646b7c2a24d8ee1f8e036ed85d"},
+    {file = "gitlint-0.19.1.tar.gz", hash = "sha256:b5b70fb894e80849b69abbb65ee7dbb3520fc3511f202a6e6b6ddf1a71ee8f61"},
+]
+
+[package.dependencies]
+gitlint-core = {version = "0.19.1", extras = ["trusted-deps"]}
+
+[[package]]
 name = "gitlint-core"
 version = "0.19.1"
 description = "Git commit message linter written in python, checks your commit messages for style."
@@ -55,9 +70,18 @@ files = [
 ]
 
 [package.dependencies]
-arrow = ">=1"
-click = ">=8"
-sh = {version = ">=1.13.0", markers = "sys_platform != \"win32\""}
+arrow = [
+    {version = ">=1"},
+    {version = "1.2.3", optional = true, markers = "extra == \"trusted-deps\""},
+]
+click = [
+    {version = ">=8"},
+    {version = "8.1.3", optional = true, markers = "extra == \"trusted-deps\""},
+]
+sh = [
+    {version = ">=1.13.0", markers = "sys_platform != \"win32\""},
+    {version = "1.14.3", optional = true, markers = "sys_platform != \"win32\""},
+]
 
 [package.extras]
 trusted-deps = ["arrow (==1.2.3)", "click (==8.1.3)", "sh (==1.14.3)"]
@@ -103,4 +127,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "adf873e9e558309a0a45d9377b383b7f101407ca573f8bfb9a7734bed7d69762"
+content-hash = "943d2992e7893036993128ae225be75f752dfe9afd349d4313f63f63c7050977"

--- a/tests/gitlint/pyproject.toml
+++ b/tests/gitlint/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
-name = "gitlint-core-test"
+name = "gitlint-test"
 version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-gitlint-core = "*"
+gitlint = "*"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Looks like it must be kept in tandem with gitlint-core (#1051).

In draft until I figure out why this fix isn't working for my work project. Even with poetry2nix 1.40.1 (nixpkgs-22.11 a08bae02236cbb2692e1230e40ddf7aff3e2225e) and this override

```nix
{
  gitlint = super.gitlint.overridePythonAttrs (
    old: {
      propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [
        self.hatchling
        self.hatch-vcs
      ];
    }
  );
}
```

the build seems to still be missing hatch-vcs somehow.

```text
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing pip-build-hook
Using pipBuildPhase
Using pipShellHook
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/kxh1djfpirxdivckxr25h0xd4gc3cg5l-gitlint_core-0.19.1.tar.gz
source root is gitlint_core-0.19.1
setting SOURCE_DATE_EPOCH to timestamp 1580601600 of file gitlint_core-0.19.1/pyproject.toml
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
Removing path dependencies
Finished removing path dependencies
Removing git dependencies
Finished removing git dependencies
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing pipBuildPhase
Creating a wheel...
[33mWARNING: The directory '/homeless-shelter/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.[0m[33m
[0mProcessing /build/gitlint_core-0.19.1
  Running command Preparing metadata (pyproject.toml)
  Traceback (most recent call last):
    File "/nix/store/0nshci8k3v28d5fz6lgx5r4wwcls366q-python3.9-pip-22.2.2/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 156, in prepare_metadata_for_build_wheel
      hook = backend.prepare_metadata_for_build_wheel
  AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_wheel'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/nix/store/0nshci8k3v28d5fz6lgx5r4wwcls366q-python3.9-pip-22.2.2/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/nix/store/0nshci8k3v28d5fz6lgx5r4wwcls366q-python3.9-pip-22.2.2/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/nix/store/0nshci8k3v28d5fz6lgx5r4wwcls366q-python3.9-pip-22.2.2/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 160, in prepare_metadata_for_build_wheel
      whl_basename = backend.build_wheel(metadata_directory, config_settings)
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/build.py", line 41, in build_wheel
      return os.path.basename(next(builder.build(wheel_directory, ['standard'])))
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/builders/plugin/interface.py", line 80, in build
      self.metadata.validate_fields()
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/metadata/core.py", line 214, in validate_fields
      _ = self.version
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/metadata/core.py", line 102, in version
      self._set_version()
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/metadata/core.py", line 191, in _set_version
      core_metadata = self.core
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/metadata/core.py", line 139, in core
      metadata_hooks = self.hatch.metadata.hooks
    File "/nix/store/w3i7ygvbr5dyzsmvy6q0abv9b8b5wwxk-python3.9-hatchling-1.11.1/lib/python3.9/site-packages/hatchling/metadata/core.py", line 1400, in hooks
      raise UnknownPluginError(f'Unknown metadata hook: {hook_name}')
  hatchling.plugin.exceptions.UnknownPluginError: Unknown metadata hook: vcs
  [1;31merror[0m: [1msubprocess-exited-with-error[0m
  
  [31m×[0m [32mPreparing metadata [0m[1;32m([0m[32mpyproject.toml[0m[1;32m)[0m did not run successfully.
  [31m│[0m exit code: [1;36m1[0m
  [31m╰─>[0m See above for output.
  
  [1;35mnote[0m: This error originates from a subprocess, and is likely not a problem with pip.
  [1;35mfull command[0m: [34m/nix/store/ndvxv84nin7kx7ya50dvvzf5f73sfi5d-python3-3.9.16/bin/python3.9 /nix/store/0nshci8k3v28d5fz6lgx5r4wwcls366q-python3.9-pip-22.2.2/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /build/tmpi4e5ldgj[0m
  [1;35mcwd[0m: /build/gitlint_core-0.19.1
  Preparing metadata (pyproject.toml) ... [?25l[?25herror
[1;31merror[0m: [1mmetadata-generation-failed[0m

[31m×[0m Encountered error while generating package metadata.
[31m╰─>[0m See above for output.

[1;35mnote[0m: This is an issue with the package mentioned above, not pip.
[1;36mhint[0m: See above for details.
```