### PR TITLE
strawberry: poetry-core -> poetry

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16986,7 +16986,7 @@
     "setuptools"
   ],
   "strawberry-graphql": [
-    "poetry-core",
+    "poetry",
     "setuptools"
   ],
   "streamdeck": [


### PR DESCRIPTION
Changes the build dependency for strawberry from poetry-core to full poetry. I'm not sure what could have changed since I assume the build was working before, but this seemed to be necessary to get my build working and [their pyproject.toml](https://github.com/strawberry-graphql/strawberry/blob/main/pyproject.toml#L33) seems to use full poetry.

Not related to this particular PR, but apparently strawberry is looking at moving away from poetry: strawberry-graphql/strawberry#2199, strawberry-graphql/strawberry#2497 in case someone finds this PR in search.