### PR TITLE
Fix override for `h5py`

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -783,7 +783,7 @@ lib.composeManyExtensions [
               ;
               propagatedBuildInputs =
                 (old.propagatedBuildInputs or [ ])
-                ++ lib.optionals mpiSupport [ self.mpi4py self.openssh ]
+                ++ lib.optionals mpiSupport [ self.mpi4py pkgs.openssh ]
               ;
               preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
               HDF5_DIR = "${pkgs.hdf5}";


### PR DESCRIPTION
Fix default override for `h5py` which was using `python3Packages.openssh` instead of `pkgs.openssh` as build input.