### PR TITLE
Bumped granian version to 0.3.1

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -710,6 +710,8 @@ lib.composeManyExtensions [
             "0.2.4" = "sha256-GdQJvVPsWgC1z7La9h11x2pRAP+L998yImhTFrFT5l8=";
             "0.2.5" = "sha256-vMXMxss77rmXSjoB53eE8XN2jXyIEf03WoQiDfvhDmw=";
             "0.2.6" = "sha256-l9W9+KDg/43mc0toEz1n1pqw+oQdiHdAxGlS+KLIGhw=";
+            "0.3.0" = "sha256-icBjtW8fZjT3mLo43nKWdirMz6GZIy/RghEO95pHJEU=";
+            "0.3.1" = "sha256-EKK+RxkJ//fY43EjvN1Fry7mn2ZLIaNlTyKPJRxyKZs=";
           }.${version};
           sha256 = getRepoHash super.granian.version;
         in


### PR DESCRIPTION
My build of [Emmett](https://emmett.sh/) was failing due to this table not containing the latest versions of [Granian](https://github.com/emmett-framework/granian/tags).

This is intended to add the needed versions.