### PR TITLE
fix(flake): build poetry with correct poetry2nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 { pkgs ? import <nixpkgs> { }
 , lib ? pkgs.lib
-, poetry ? null
 , poetryLib ? import ./lib.nix { inherit lib pkgs; stdenv = pkgs.stdenv; }
 }:
 let

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        poetry = pkgs.callPackage ./pkgs/poetry { python = pkgs.python3; };
-        poetry2nix = import ./default.nix { inherit pkgs poetry; };
+        poetry2nix = import ./default.nix { inherit pkgs; };
+        poetry = pkgs.callPackage ./pkgs/poetry { python = pkgs.python3; inherit poetry2nix; };
       in
       rec {
         packages = {

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,6 @@
 final: prev: {
 
-  poetry2nix = import ./default.nix { pkgs = final; poetry = final.poetry; };
+  poetry2nix = import ./default.nix { pkgs = final; };
 
   poetry = prev.callPackage ./pkgs/poetry { python = final.python3; };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -13,7 +13,7 @@ in
 }:
 let
   poetry = pkgs.callPackage ../pkgs/poetry { python = pkgs.python3; inherit poetry2nix; };
-  poetry2nix = import ./.. { inherit pkgs; inherit poetry; };
+  poetry2nix = import ./.. { inherit pkgs; };
   poetryLib = import ../lib.nix { inherit pkgs; lib = pkgs.lib; stdenv = pkgs.stdenv; };
   pep425 = pkgs.callPackage ../pep425.nix { inherit poetryLib; python = pkgs.python3; };
   pep425PythonOldest = pkgs.callPackage ../pep425.nix { inherit poetryLib; python = pkgs.python38; };


### PR DESCRIPTION
Also remove the completely unused `poetry` argument from `default.nix` as to not confuse people even more.