### PR TITLE
Add setuptools to psycopg-pool and poetry-core to sqlmodel build deps

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11626,6 +11626,9 @@
   "psycopg": [
     "setuptools"
   ],
+  "psycopg-pool": [
+    "setuptools"
+  ],
   "psycopg2": [
     "setuptools"
   ],
@@ -16864,6 +16867,9 @@
   ],
   "sqlmap": [
     "setuptools"
+  ],
+  "sqlmodel": [
+    "poetry-core"
   ],
   "sqlobject": [
     "setuptools"


### PR DESCRIPTION
This should allow building projects that depend on sqlmodel or psycopg[pool].