### PR TITLE
orjson: update getCargoHash

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1553,6 +1553,7 @@ lib.composeManyExtensions [
             "3.8.6" = "sha256-8T//q6nQoZhh8oJWDCeQf3gYRew58dXAaxkYELY4CJM=";
             "3.8.7" = "sha256-JBO8nl0sC+XIn17vI7hC8+nA1HYI9jfvZrl9nCE3k1s=";
             "3.8.8" = "sha256-AK4HtqPKg2O2FeLHCbY9o+N1BV4QFMNaHVE1NaFYHa4=";
+            "3.8.10" = "sha256-AcrTEHv7GYtGe4fXYsM24ElrzfhnOxLYlaon1ZrlD4A=";
           }.${version} or (
             lib.warn "Unknown orjson version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
I ran into the following error
```
warning: Git tree '/Users/raphael/dev/text-generation-webui' is dirty
trace: warning: Unknown orjson version: '3.8.10'. Please update getCargoHash.
fetching submodules of 'https://github.com/huggingface/peft'warning: refname 'HEAD' is ambiguous.
error: hash mismatch in fixed-output derivation '/nix/store/xky1yz2rd8wl9xdnp4ys4rhmpg3ccb1y-orjson-3.8.10-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-AcrTEHv7GYtGe4fXYsM24ElrzfhnOxLYlaon1ZrlD4A=
```
and it wasn't immediately clear to me how to use the overrides to override that.
If you have any pointers as to how to override that locally, I'd be happy to make a doc PR.