### PR TITLE
Add setuptools to tkcalendar

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17683,10 +17683,10 @@
     "setuptools",
     "setuptools-scm"
   ],
-  "tkinter": [
+  "tkcalendar": [
     "setuptools"
   ],
-  "tkcalendar": [
+  "tkinter": [
     "setuptools"
   ],
   "tld": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17686,6 +17686,9 @@
   "tkinter": [
     "setuptools"
   ],
+  "tkcalendar": [
+    "setuptools"
+  ],
   "tld": [
     "setuptools"
   ],


### PR DESCRIPTION
Hello there :wave: 

I was trying to build a project that had a dependency on `tkcalendar` and I got this error:
```
λ nix build
error: builder for '/nix/store/b9dplp5dfmdf8ywg3l0c3awj10vdivkn-python3.10-tkcalendar-1.6.1.drv' failed with exit code 2;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
       > ModuleNotFoundError: No module named 'setuptools'
       > 
```

So, this is just to add setuptools to the list of build-systems.