### PR TITLE
Set versioneer for pandas

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10722,7 +10722,11 @@
   ],
   "pandas": [
     "cython",
-    "setuptools"
+    "setuptools",
+    {
+      "buildSystem": "versioneer",
+      "from": "2.0.0"
+    }
   ],
   "pandas-datareader": [
     "setuptools"


### PR DESCRIPTION
Fixes https://github.com/nix-community/poetry2nix/issues/1127 when using Python 3.11

Maybe there is a fix for this to work with Python 3.10, but it seems like versioneer only [supports toml at python 3.11+](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/versioneer/default.nix#L25).