### PR TITLE
Don't fail to apply overrides if a package does not exist (yet)

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -76,7 +76,7 @@ lib.composeManyExtensions [
         (drv: attr: addBuildSystem {
           inherit drv self attr;
         })
-        super.${attr}
+        (super.${attr} or null)
         systems)
       buildSystems)
 


### PR DESCRIPTION
It happens every so often that the nixpkgs that `poetry2nix` uses, defines overrides for packages that don't exist in the nixpkgs that we use (nixos-22.11).
This patch allows us to still use the newer version of poetry2nix.