### PR TITLE
mkPoetryEnv: add checkGroups

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -324,6 +324,7 @@ lib.makeScope pkgs.newScope (self: {
     , editablePackageSources ? { }
     , extraPackages ? ps: [ ]
     , groups ? [ "dev" ]
+    , checkGroups ? [ "dev" ]
     , extras ? [ "*" ]
     }:
     let
@@ -357,7 +358,7 @@ lib.makeScope pkgs.newScope (self: {
         excludedEditablePackageNames;
 
       poetryPython = self.mkPoetryPackages {
-        inherit pyproject poetrylock overrides python pwd preferWheels pyProject groups extras;
+        inherit pyproject poetrylock overrides python pwd preferWheels pyProject groups checkGroups extras;
         editablePackageSources = editablePackageSources';
       };
 


### PR DESCRIPTION
Currently it is not possible to remove the "dev" group when using mkPoetryEnv: the "dev" group is still built because it is part of the `checkGroups`. To be able to avoid this, I opted to add `checkGroups` to `mkPoetryEnv`, just like what you would be able to in `mkPoetryApplication` and `mkPoetryPackages`.

This is a step towards resolving https://github.com/nix-community/poetry2nix/issues/627 properly.