### PR TITLE
overrides: add Accelerate framework for opencv on darwin

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1521,6 +1521,7 @@ lib.composeManyExtensions [
           buildInputs = [
             self.scikit-build
           ] ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            Accelerate
             AVFoundation
             Cocoa
             CoreMedia


### PR DESCRIPTION
Copies fix for nixpkgs.opencv in https://github.com/NixOS/nixpkgs/pull/225378