### PR TITLE
fix: DuckDB overwrite

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -581,6 +581,8 @@ lib.composeManyExtensions [
 
       duckdb = super.duckdb.overridePythonAttrs (old: {
         postPatch = lib.optionalString (!(old.src.isWheel or false)) ''
+          cd tools/pythonpkg
+
           substituteInPlace setup.py \
             --replace 'multiprocessing.cpu_count()' "$NIX_BUILD_CORES" \
             --replace 'setuptools_scm<7.0.0' 'setuptools_scm'


### PR DESCRIPTION
This small patch adjust the DuckDB overwrite to work with the current package structure that relocate [setup.py](https://github.com/duckdb/duckdb/blob/master/tools/pythonpkg/setup.py) (from `/` -> `/tools/pythonpkg`). I came across this error when trying to use DuckDB with jupyenv. The actual source for the fix is nixpkg's version of [python3Packages.duckdb](https://github.com/NixOS/nixpkgs/blob/3ed18a352739221ebaba0d11c38a2158faa29887/pkgs/development/python-modules/duckdb/default.nix#L22) that includes this adjustment already.