### PR TITLE
urllib3: Used flit-core until 2.0.2 and hatchling since

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -18730,6 +18730,14 @@
     "setuptools"
   ],
   "urllib3": [
+    {
+      "buildSystem": "flit-core",
+      "until": "2.0.2"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "2.0.2"
+    },
     "setuptools"
   ],
   "urlpy": [


### PR DESCRIPTION
See https://github.com/urllib3/urllib3/commit/8dda1974ae51839304f8517ab7993006c0d9db2e for the commit to change from `flit_core` to `hatchling`.