### PR TITLE
lib: Include isWheel for fetchFromLegacy

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -161,6 +161,7 @@ let
         outputHashAlgo = "sha256";
         outputHash = hash;
         NETRC = netrc_file;
+        passthru.isWheel = lib.strings.hasSuffix "whl" file;
       } ''
       python ${./fetch_from_legacy.py} ${url} ${pname} ${file}
       mv ${file} $out


### PR DESCRIPTION
There is a bunch of overrides that relies on the `src.isWheel` attribute, which is not set at all when `fetchFromLegacy` is used.