### PR TITLE
overrides: eth-keyfile: runtime dep on setuptools

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -603,11 +603,13 @@ lib.composeManyExtensions [
         '';
       };
 
-      eth-keyfile = super.eth-keyfile.overridePythonAttrs {
+      eth-keyfile = super.eth-keyfile.overridePythonAttrs (old: {
         preConfigure = ''
           substituteInPlace setup.py --replace \'setuptools-markdown\' ""
         '';
-      };
+
+        propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.setuptools ];
+      });
 
       eth-keys = super.eth-keys.overridePythonAttrs {
         preConfigure = ''


### PR DESCRIPTION
The lack of this would trigger runtime errors like:

```
  File "/nix/store/sp8sipvizxaadiws38h9x0szyn3m63a7-python3.9-web3-trio-1.0.3/lib/python3.9/site-packages/web3_trio/transaction.py", line 6, in <module>
    import eth_account
  File "/nix/store/2mf213pkc3yqpiimqpc8vsh9az45wqdi-python3.9-eth-account-0.7.0/lib/python3.9/site-packages/eth_account/__init__.py", line 1, in <module>
    from eth_account.account import (
  File "/nix/store/2mf213pkc3yqpiimqpc8vsh9az45wqdi-python3.9-eth-account-0.7.0/lib/python3.9/site-packages/eth_account/account.py", line 18, in <module>
    from eth_keyfile import (
  File "/nix/store/yxikh4an09sax2imjc7f4qf8anlr7mnc-python3.9-eth-keyfile-0.6.1/lib/python3.9/site-packages/eth_keyfile/__init__.py", line 3, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```