### PR TITLE
Add setuptools for dask tooling.

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -3652,7 +3652,11 @@
     "setuptools"
   ],
   "dask": [
-    "setuptools"
+    "setuptools",
+    {
+      "buildSystem": "versioneer",
+      "from": "2.0.0"
+    }
   ],
   "dask-gateway": [
     "setuptools"
@@ -4136,7 +4140,11 @@
     "setuptools"
   ],
   "distributed": [
-    "setuptools"
+    "setuptools",
+    {
+      "buildSystem": "versioneer",
+      "from": "2.0.0"
+    }
   ],
   "distro": [
     "setuptools"
@@ -8362,6 +8370,10 @@
   ],
   "konnected": [
     "setuptools"
+  ],
+  "kopf": [
+    "setuptools",
+    "setuptools-scm"
   ],
   "korean-lunar-calendar": [
     "setuptools"
@@ -12939,6 +12951,9 @@
     "setuptools"
   ],
   "pykwb": [
+    "setuptools"
+  ],
+  "pykube-ng": [
     "setuptools"
   ],
   "pylacrosse": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -12944,6 +12944,9 @@
   "pykrakenapi": [
     "setuptools"
   ],
+  "pykube-ng": [
+    "setuptools"
+  ],
   "pykulersky": [
     "setuptools"
   ],
@@ -12951,9 +12954,6 @@
     "setuptools"
   ],
   "pykwb": [
-    "setuptools"
-  ],
-  "pykube-ng": [
     "setuptools"
   ],
   "pylacrosse": [


### PR DESCRIPTION
Hi,

I have a project that uses the dask set of tools and wanted to take advantage of poetry2nix. Since they all rely on pandas 2.0, I believe they need "versioneer" listed in the build-systems overrides. Also added entries for pykube-ng and kopf which is used by dask_kubernetes.

This was enough to get everything to build in the project, however If this is the wrong way to do this feel free to close!