### PR TITLE
Add build systems for genson, jsonref

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -6131,6 +6131,9 @@
     "cython",
     "setuptools"
   ],
+  "genson": [
+    "setuptools"
+  ],
   "gentools": [
     "setuptools"
   ],
@@ -7982,6 +7985,11 @@
   "jsonref": [
     {
       "buildSystem": "setuptools",
+      "until": "0.3.0"
+    },
+    {
+      "buildSystem": "poetry",
+      "from": "0.3.0",
       "until": "1.1.0"
     },
     {


### PR DESCRIPTION
- Add build system (setuptools) for genson
- Add build system (poetry) for jsonref >= 0.3.0, < 1.1.0