### PR TITLE
FAQ: Clarify poetry2nix does not use nixpkgs for Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ in pkgs.poetry2nix.mkPoetryApplication {
 
 **A.** By default, poetry2nix installs from source. If you want to give precedence to wheels, look at the `preferWheel` and `preferWheels` attributes.
 
+**Q.** Does poetry2nix use package definitions from nixpkgs' Python package set?
+
+**A.** No.
+
 **Q.** How to prefer wheel installation for a single package?
 
 **A.** Override it and set `preferWheel = true` in that single package:

--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ in pkgs.poetry2nix.mkPoetryApplication {
 
 **Q.** Does poetry2nix use package definitions from nixpkgs' Python package set?
 
-**A.** No.
+**A.** poetry2nix overlays packages taken from the `poetry.lock` file on top of nixpkgs, in such a way that overlaid packages in nixpkgs are completely ignored.
+Any package that is used, but isn't in the `poetry.lock` file (most commonly [build dependencies](https://github.com/nix-community/poetry2nix/blob/master/overrides/build-systems.json)) is taken from nixpkgs.
 
 **Q.** How to prefer wheel installation for a single package?
 


### PR DESCRIPTION
I'm sure this could be expanded upon, and maybe this PR can provide the impetus for that.