### PR TITLE
open3d: don't include mesa on Darwin

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1504,8 +1504,9 @@ lib.composeManyExtensions [
           pkgs.libusb1
         ] ++ lib.optionals stdenv.isLinux [
           pkgs.udev
-        ] ++ lib.optionals (lib.versionAtLeast super.open3d.version "0.16.0") [
+        ] ++ lib.optionals (lib.versionAtLeast super.open3d.version "0.16.0" && !pkgs.mesa.meta.broken) [
           pkgs.mesa
+        ] ++ lib.optionals (lib.versionAtLeast super.open3d.version "0.16.0") [
           (
             pkgs.symlinkJoin {
               name = "llvm-with-ubuntu-compatible-symlink";


### PR DESCRIPTION
It's an optional dependency (AFAICT) and the current version of mesa is broken in nixpkgs