### PR TITLE
overrides: discord-py

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -4029,6 +4029,9 @@
   "discogs-client": [
     "setuptools"
   ],
+  "discord-py": [
+    "setuptools"
+  ],
   "discordpy": [
     "setuptools"
   ],


### PR DESCRIPTION
This package doesn't build without setuptools.