### PR TITLE
Fix override recommonmark and rich mixup

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2308,7 +2308,7 @@ lib.composeManyExtensions [
         }
       );
 
-      recommonmark = super.rich.overridePythonAttrs (
+      recommonmark = super.recommonmark.overridePythonAttrs (
         old: {
           buildInputs = (old.buildInputs or [ ]) ++ [ self.commonmark ];
         }


### PR DESCRIPTION
I was wondering why recommonmark did not appear in my environment :)

I've made that mistake a few times as well and it's rather confusing, is there a pattern which could avoid the name repetition?