### PR TITLE
Update overrides for `jsonschema` 4.18.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -463,7 +463,6 @@ lib.makeScope pkgs.newScope (self: {
   /* Poetry2nix CLI used to supplement SHA-256 hashes for git dependencies  */
   cli = import ./cli.nix {
     inherit pkgs lib;
-    inherit (self) version;
   };
 
   # inherit mkPoetryEnv mkPoetryApplication mkPoetryPackages;

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -15613,6 +15613,10 @@
     "cython",
     "setuptools"
   ],
+  "referencing": [
+    "hatch-vcs",
+    "hatchling"
+  ],
   "reflink": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -8069,6 +8069,10 @@
   "jsonschema-spec": [
     "poetry-core"
   ],
+  "jsonschema-specifications": [
+    "hatch-vcs",
+    "hatchling"
+  ],
   "jsonstreams": [
     "setuptools"
   ],

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1025,6 +1025,12 @@ lib.composeManyExtensions [
             })
         else super.jsonschema;
 
+      jsonschema-specifications = super.jsonschema-specifications.overridePythonAttrs (old: {
+        postPatch = old.postPatch or "" + ''
+          sed -i "/Topic :: File Formats :: JSON/d" pyproject.toml
+        '';
+      });
+
       jupyter = super.jupyter.overridePythonAttrs (
         old: {
           # jupyter is a meta-package. Everything relevant comes from the

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2372,6 +2372,12 @@ lib.composeManyExtensions [
         nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.gdal ];
       });
 
+      referencing = super.referencing.overridePythonAttrs (old: {
+        postPatch = old.postPatch or "" + ''
+          sed -i "/Topic :: File Formats :: JSON/d" pyproject.toml
+        '';
+      });
+
       rfc3986-validator = super.rfc3986-validator.overridePythonAttrs (old: {
         nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
           self.pytest-runner

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1022,6 +1022,9 @@ lib.composeManyExtensions [
           super.jsonschema.overridePythonAttrs
             (old: {
               propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.importlib-resources ];
+              postPatch = old.postPatch or "" + lib.optionalString (lib.versionAtLeast super.jsonschema.version "4.18.0") ''
+                sed -i "/Topic :: File Formats :: JSON/d" pyproject.toml
+              '';
             })
         else super.jsonschema;
 


### PR DESCRIPTION
[`jsonschema` 4.18.0](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0) gained a bunch of new dependencies which need overrides to build:
- [`rpds-py`](https://github.com/crate-py/rpds):
  - uses Rust and Cargo, and therefore the override would require updating the Cargo hash after every new release;
- [`referencing`](https://github.com/python-jsonschema/referencing):
  - uses the `hatchling` and `hatch-vcs` build system packages;
  - declares classifiers which are not accepted by `hatchling` 1.13.0 (the minimum requirements are apparently `hatchling` >= 1.14.0 and `trove-classifiers` >= 2023.4.25); updating `hatchling` would be really complicated, so the offending classifiers are patched out in `postPatch`;
- [`jsonschema-specifications`](https://github.com/python-jsonschema/jsonschema-specifications):
  - uses the `hatchling` and `hatch-vcs` build system packages;
  - also declares classifiers which are not accepted by `hatchling` 1.13.0 and need to be patched out.

Also the `jsonschema` 4.18.0 package itself declares the same problematic classifiers and therefore needs the same code in `postPatch`.