### PR TITLE
Fix CLI after removal of `version`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -463,7 +463,6 @@ lib.makeScope pkgs.newScope (self: {
   /* Poetry2nix CLI used to supplement SHA-256 hashes for git dependencies  */
   cli = import ./cli.nix {
     inherit pkgs lib;
-    inherit (self) version;
   };
 
   # inherit mkPoetryEnv mkPoetryApplication mkPoetryPackages;


### PR DESCRIPTION
The CI test `cli` broke:
```
$ nix-build --dry-run --keep-going --show-trace tests/default.nix -A cli
error:
       … from call site

         at /home/runner/work/poetry2nix/poetry2nix/default.nix:464:9:

          463|   /* Poetry2nix CLI used to supplement SHA-256 hashes for git dependencies  */
          464|   cli = import ./cli.nix {
             |         ^
          465|     inherit pkgs lib;

       error: function 'anonymous lambda' called with unexpected argument 'version'

       at /home/runner/work/poetry2nix/poetry2nix/cli.nix:1:1:

            1| { pkgs ? import <nixpkgs> { }
             | ^
            2| , lib ? pkgs.lib
nix-build-uncached: --dry-run failed: exit status 1
```
Remove the leftover `version` argument to fix that.