### PR TITLE
preferWheels improvements

### DIFF
--- a/pep425.nix
+++ b/pep425.nix
@@ -97,7 +97,7 @@ let
           then
           # See PEP 600 for details.
             (p:
-              builtins.match "any|manylinux(1|2010|2014)_${escapeRegex targetMachine}|manylinux_[0-9]+_[0-9]+_${escapeRegex targetMachine}" p != null
+              builtins.match "any|(linux|manylinux(1|2010|2014))_${escapeRegex targetMachine}|manylinux_[0-9]+_[0-9]+_${escapeRegex targetMachine}" p != null
             )
           else
             (p: p == "any")
@@ -118,7 +118,7 @@ let
       choose = files:
         let
           osxMatches = [ "12_0" "11_0" "10_15" "10_14" "10_12" "10_11" "10_10" "10_9" "10_8" "10_7" "any" ];
-          linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "manylinux_" "any" ];
+          linuxMatches = [ "manylinux1_" "manylinux2010_" "manylinux2014_" "manylinux_" "linux_" "any" ];
           chooseLinux = x: lib.take 1 (findBestMatches linuxMatches x);
           chooseOSX = x: lib.take 1 (findBestMatches osxMatches x);
         in

--- a/pep425.nix
+++ b/pep425.nix
@@ -11,7 +11,9 @@ let
       tags = [ "cp" "py" ];
     in
     { inherit major minor tags; };
-  abiTag = "cp${pythonVer.major}${pythonVer.minor}m";
+  # Builds with and without pymalloc (m) are ABI compatible since python 3.8 (bpo-36707)
+  abiTag = "cp${pythonVer.major}${pythonVer.minor}"
+    + lib.optionalString (builtins.compareVersions python.version "3.8" < 0) "m";
 
   #
   # Parses wheel file returning an attribute set


### PR DESCRIPTION
This PR is two-part, mainly aiding `preferWheels=true`.

---

The `m` abi flag has [since python 3.8](https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes) become obsolete, as builds with and without pymalloc are now compatible.

---

Some wheels use the abi `linux` instead of `manylinux`. [Pytorch3d](https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py38_cu113_pyt1110/download.html) (via [this](https://github.com/facebookresearch/pytorch3d/blob/main/INSTALL.md#3-install-wheels-for-linux)) is one such example. Both poetry and pip seem to accept it, so why not?
