### PR TITLE
Add support for building Python 2 applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Creates a Python application using the Python interpreter specified based on the
 - **overrides**: Python overrides to apply (_default_: `defaultPoetryOverrides`).
 - **meta**: application [meta](https://nixos.org/nixpkgs/manual/#chap-meta) data (_default:_ `{}`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
+- **buildPython**: The Python interpreter to use for building (_default:_ `python`).
 - **preferWheels** : Use wheels rather than sdist as much as possible (_default_: `false`).
 - **groups**: Which Poetry 1.2.0+ dependency groups to install (_default_: `[ ]`).
 - **extras**: Which Poetry `extras` to install (_default_: `[ "*" ]`, all extras).

--- a/default.nix
+++ b/default.nix
@@ -73,7 +73,7 @@ let
         ++ lib.flatten (map (g: getDeps (pyProject.tool.poetry.group.${g}.dependencies or { })) checkGroups);
     in
     {
-      buildInputs = mkInput "buildInputs" (if includeBuildSystem then buildSystemPkgs else [ ]);
+      buildInputs = mkInput "buildInputs" [ ];
       propagatedBuildInputs = mkInput "propagatedBuildInputs" (
         getDeps allRawDeps ++ (
           # >=poetry-1.2.0 dependency groups
@@ -82,7 +82,7 @@ let
           else [ ]
         )
       );
-      nativeBuildInputs = mkInput "nativeBuildInputs" [ ];
+      nativeBuildInputs = mkInput "nativeBuildInputs" (if includeBuildSystem then buildSystemPkgs else [ ]);
       checkInputs = mkInput "checkInputs" checkInputs';
       nativeCheckInputs = mkInput "nativeCheckInputs" checkInputs';
     };

--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -240,3 +240,27 @@ error: infinite recursion encountered
 ```
 
 This is because `dask[distributed]` depends on `distributed` which depends on `dask`. The solution is to install `dask` (no extras) and `distributed` separately.
+
+#### Building Python 2 applications
+
+Poetry has [dropped support for using Python
+2](https://python-poetry.org/blog/announcing-poetry-1.2.0/#dropping-support-for-managing-python-27-projects)
+as the runtime version. This means you can't run Poetry with Python 2, but you
+can run it with a newer version of Python to build a legacy application which
+still uses Python 2.
+
+To do this in poetry2nix, use the `buildPython` argument to use specify the
+build and runtime Python versions separately:
+
+```nix
+{ poetry2nix, python2, python3, ...}:
+
+poetry2nix.mkPoetryApplication {
+  projectDir = ./.;
+  python = python2;
+  buildPython = python3;
+  # ...
+}
+```
+
+Note that the default poetry2nix overrides and generally not tested for Python 2. As a result more manual overrides may be necessary when packaging a Python 2 application with poetry2nix.


### PR DESCRIPTION
By allowing the build-time Python runtime to be overridden.

This is handy for packaging legacy Python 2.7 applications with poetry2nix.

Convert the poetry2nix build-time inputs to `nativeBuildInputs` rather than `buildInputs`. This prevents mixed Python derivations from causing a "Python version mismatch in ..." error.

This is a succinct proof-of-concept to gauge interest, since it's not a huge change (in terms of line count) and I'd like to share this patch for anyone who's interested.

To do:

* [ ] optimise the `self.mkPoetryPackages` calls. The `buildPython` particularly needs the overlays which add `poetry` and `poetry-core`
  * find the minimal overlays for each runtime and refactor
* [ ] add a test for a Python 2 package
  * what would be a good candidate?
* [ ] support other `mkPoetry*` functions?