### PR TITLE
Extend execnet overrides

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5179,6 +5179,8 @@
     "setuptools"
   ],
   "execnet": [
+    "hatchling",
+    "hatch-vcs",
     "setuptools",
     "setuptools-scm"
   ],


### PR DESCRIPTION
Execnet 2.0.2 now requires hatchling and hatch-vcs to build.