### PR TITLE
fix: also use `allRefs = true` when branch is given

### DIFF
--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -177,10 +177,12 @@ pythonPackages.callPackage
               rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             } // (
-              lib.optionalAttrs (((sourceSpec ? rev) || (sourceSpec ? branch) || (source ? resolved_reference) || (source ? reference))
-                                 && (lib.versionAtLeast builtins.nixVersion "2.4")) {
-                allRefs = true;
-              }) // (
+              lib.optionalAttrs
+                (((sourceSpec ? rev) || (sourceSpec ? branch) || (source ? resolved_reference) || (source ? reference))
+                  && (lib.versionAtLeast builtins.nixVersion "2.4"))
+                {
+                  allRefs = true;
+                }) // (
               lib.optionalAttrs (lib.versionAtLeast builtins.nixVersion "2.4") {
                 submodules = true;
               })

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -177,7 +177,7 @@ pythonPackages.callPackage
               rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             } // (
-              lib.optionalAttrs ((sourceSpec ? rev) && (lib.versionAtLeast builtins.nixVersion "2.4")) {
+              lib.optionalAttrs (((sourceSpec ? rev) || (sourceSpec ? branch)) && (lib.versionAtLeast builtins.nixVersion "2.4")) {
                 allRefs = true;
               }) // (
               lib.optionalAttrs (lib.versionAtLeast builtins.nixVersion "2.4") {

--- a/mk-poetry-dep.nix
+++ b/mk-poetry-dep.nix
@@ -177,7 +177,8 @@ pythonPackages.callPackage
               rev = source.resolved_reference or source.reference;
               ref = sourceSpec.branch or (if sourceSpec ? tag then "refs/tags/${sourceSpec.tag}" else "HEAD");
             } // (
-              lib.optionalAttrs (((sourceSpec ? rev) || (sourceSpec ? branch)) && (lib.versionAtLeast builtins.nixVersion "2.4")) {
+              lib.optionalAttrs (((sourceSpec ? rev) || (sourceSpec ? branch) || (source ? resolved_reference) || (source ? reference))
+                                 && (lib.versionAtLeast builtins.nixVersion "2.4")) {
                 allRefs = true;
               }) // (
               lib.optionalAttrs (lib.versionAtLeast builtins.nixVersion "2.4") {


### PR DESCRIPTION
Fixes an issue where branches not created from upstream `HEAD` could not be found