### PR TITLE
Update build-systems.json for sphinxcontrib-jquery

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17138,6 +17138,9 @@
     "pbr",
     "setuptools"
   ],
+  "sphinx-js": [
+    "setuptools"
+  ],
   "sphinx-jupyterbook-latex": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17216,6 +17216,16 @@
   "sphinxcontrib-httpdomain": [
     "setuptools"
   ],
+  "sphinxcontrib-jquery": [
+    {
+      "buildSystem": "setuptools",
+      "until": "3.0.0"
+    },
+    {
+      "buildSystem": "flit-core",
+      "from": "3.0.0"
+    }
+  ],
   "sphinxcontrib-jsmath": [
     "setuptools"
   ],


### PR DESCRIPTION
First time contributor to this repo.  I am not sure of what the best method for testing this update is _in situ_.  I found that this override fixed an issue with building `sphinx-rtd-theme` with poetry2nix (i.e., `sphinxcontriib-jquery` not being able to find `flit_core`).