### PR TITLE
overrides for gunicorn, service-identity and flask-discord-interactions

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5690,6 +5690,9 @@
   "flask-cors": [
     "setuptools"
   ],
+  "flask-discord-interactions": [
+    "setuptools"
+  ],
   "flask-elastic": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16585,7 +16585,22 @@
     "setuptools"
   ],
   "service-identity": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "23.1.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "23.1.0"
+    },
+    {
+      "buildSystem": "hatch-vcs",
+      "from": "23.1.0"
+    },
+    {
+      "buildSystem": "hatch-fancy-pypi-readme",
+      "from": "23.1.0"
+    }
   ],
   "setproctitle": [
     "setuptools"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -771,7 +771,8 @@ lib.composeManyExtensions [
 
       gunicorn = super.gunicorn.overridePythonAttrs (old: {
         # actually needs setuptools as a runtime dependency
-        propagatedBuildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
+        # 21.0.0 starts transition away from runtime dependency, starting with packaging
+        propagatedBuildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools self.packaging ];
       });
 
       h3 = super.h3.overridePythonAttrs (


### PR DESCRIPTION
Some overrides I've ran into while packaging an application.

The gunicorn one is weird since they added a runtime dependency with https://github.com/benoitc/gunicorn/pull/2963 but did not declare it.

The runtime dependency on setup-tools might disappear soon as well: https://github.com/benoitc/gunicorn/issues/2747