### PR TITLE
Add hatchling to altair

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -650,6 +650,7 @@
     "setuptools"
   ],
   "altair": [
+    "hatchling",
     "setuptools"
   ],
   "amaranth": [


### PR DESCRIPTION
@adisbladis this is my first attempt at this, the nix override equivalent that makes it work locally is:
```
altair = super.altair.overridePythonAttrs (
  old: { nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ self.hatchling ]; }
);
```