### PR TITLE
semver: Better support for PEP440 suffixes 

### DIFF
--- a/semver.nix
+++ b/semver.nix
@@ -53,7 +53,7 @@ let
     };
   re = {
     operators = "([=><!~^]+)";
-    version = "([0-9.*x]+)";
+    version = "([0-9.*x]+[^ ]*)";
   };
   parseConstraint = constraint:
     let


### PR DESCRIPTION
If we have packages like
```
[package.dependencies]
pytz = "*"
setuptools = ">=0.7"
six = ">=1.4.0"
tzlocal = ">=2.0,<3.dev0 || >=4.dev0"
```

or

```
[[package]]
name = "ndg-httpsclient"
version = "0.5.1"
description = "Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL"
optional = false
python-versions = ">=2.7,<3.0.dev0 || >=3.4.dev0"
files = [
    {file = "ndg_httpsclient-0.5.1-py2-none-any.whl", hash = "sha256:d2c7225f6a1c6cf698af4ebc962da70178a99bcde24ee6d1961c4f3338130d57"},
    {file = "ndg_httpsclient-0.5.1-py3-none-any.whl", hash = "sha256:dd174c11d971b6244a891f7be2b32ca9853d3797a72edb34fa5d7b07d8fff7d4"},
    {file = "ndg_httpsclient-0.5.1.tar.gz", hash = "sha256:d72faed0376ab039736c2ba12e30695e2788c4aa569c9c3e3d72131de2592210"},
]
```

We can get errors like `error: Constraint "<3.0.dev0" could not be
parsed`. This PEP
(https://peps.python.org/pep-0440/#inclusive-ordered-comparison)
suggests that these versions are legit and thus poetry2nix should be
able to parse them.

This support isn't perfect because it's overly broad and ultimately
still uses `builtins.compareVersions` which inherently cannot be
compatible with pythonisms.

This seems to be good enough, however to allow these packages to be
built with the correct versions.