### PR TITLE
overrides: add build system for cachecontrol and notebook

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -2592,7 +2592,14 @@
     "setuptools"
   ],
   "cachecontrol": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "0.13.1"
+    },
+    {
+      "buildSystem": "flit-core",
+      "from": "0.13.1"
+    }
   ],
   "cached-property": [
     "setuptools"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1509,6 +1509,21 @@ lib.composeManyExtensions [
         }
       );
 
+      notebook =
+        if (lib.versionAtLeast super.notebook.version "7.0.0") then
+          super.notebook.overridePythonAttrs
+            (old: ({
+              buildInputs = (old.buildInputs or [ ]) ++ [
+                super.hatchling
+                super.hatch-jupyter-builder
+              ];
+              # notebook requires jlpm which is in jupyterlab
+              # https://github.com/jupyterlab/jupyterlab/blob/main/jupyterlab/jlpmapp.py
+              nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+                super.jupyterlab
+              ];
+            })) else super.notebook;
+
       # The following are dependencies of torch >= 2.0.0.
       # torch doesn't officially support system CUDA, unless you build it yourself.
       nvidia-cudnn-cu11 = super.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {


### PR DESCRIPTION
* `cachecontrol` switches to flit-core since 0.13.1: https://github.com/psf/cachecontrol/commit/a2f92fdee213729db1dbd35ede7efb1ad8e87617

* `notebook` switches to hatch backend since 7.0.0:
https://github.com/jupyter/notebook/commit/614e4780b88f5cf5e2bfda39a55357a0be5ef161
  And since it require `jlpm` command which is a npm wrapper from `jupyter` package at build time, I have to add it to nativeBuildInputs.