### PR TITLE
chore!: make cli package/app compatible with flake

### DIFF
--- a/cli.nix
+++ b/cli.nix
@@ -3,9 +3,10 @@
 }:
 let
   inherit (pkgs) python3;
+  pname = "poetry2nix-cli";
 in
 pkgs.stdenv.mkDerivation {
-  pname = "poetry2nix-cli";
+  inherit pname;
   version = "0";
 
   buildInputs = [
@@ -22,6 +23,7 @@ pkgs.stdenv.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
+    # this is the ./bin/poetry2nix
     patchShebangs poetry2nix
     runHook postBuild
   '';
@@ -29,9 +31,10 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    mv poetry2nix $out/bin
+    # need to remap this to be consistent with `pkgs.lib.getBin` "standard"
+    mv poetry2nix $out/bin/${pname}
 
-    wrapProgram $out/bin/poetry2nix --prefix PATH ":" ${lib.makeBinPath [
+    wrapProgram $out/bin/${pname} --prefix PATH ":" ${lib.makeBinPath [
       pkgs.nix-prefetch-git
     ]}
 


### PR DESCRIPTION
Basically make the `cli` derivation to conform with `pkgs.lib.getBin` "standard", so that flakes can recognize the binary

Before:
```
% ❯ nix run .#
error: unable to execute '/nix/store/8ich1m9piml9g77ik965ixnn27g6gxqq-poetry2nix-cli
-0/bin/poetry2nix-cli': No such file or directory

```

After:
```
% ❯ nix run .#
warning: Git tree '/Users/htran/local_repos/poetry2nix' is dirty
usage: .poetry2nix-cli-wrapped [-h] {lock} ...
.poetry2nix-cli-wrapped: error: the following arguments are required: subcommand
```