### PR TITLE
Add mpremote to overrides/build-systems.json

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9720,6 +9720,11 @@
     "setuptools",
     "setuptools-scm"
   ],
+  "mpremote": [
+    "hatchling",
+    "hatch-requirements-txt",
+    "hatch-vcs"
+  ],
   "mpv": [
     "setuptools"
   ],


### PR DESCRIPTION
mpremote is built using hatchling, with some plugins. This PR adds the override required to build it.