### PR TITLE
pydatinc-settings -> hatchling

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9425,9 +9425,6 @@
   "minikerberos": [
     "setuptools"
   ],
-  "minimal-dydb": [
-    "poetry-core"
-  ],
   "minimock": [
     "setuptools"
   ],
@@ -12635,8 +12632,8 @@
       "from": "2.0.0"
     }
   ],
-  "pydantic-dydb": [
-    "poetry-core"
+  "pydantic-settings": [
+    "hatchling"
   ],
   "pydash": [
     "setuptools"


### PR DESCRIPTION
pydantic v2 spun up BaseSettings into a separate package called pydantic-settings.

Also removing pydantic-dydb and minimal-dydb as they are no longer on PyPI.