### PR TITLE
auto_version: make the tags parse under semver

### DIFF
--- a/tools/auto_version.py
+++ b/tools/auto_version.py
@@ -7,4 +7,4 @@ if __name__ == "__main__":
     modifier = int(
         (now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
     )
-    print(now.strftime(f"%-Y%m.%-d.{modifier}"))
+    print(now.strftime(f"%-Y.%-m.%-d{modifier}"))

--- a/tools/auto_version.py
+++ b/tools/auto_version.py
@@ -7,4 +7,4 @@ if __name__ == "__main__":
     modifier = int(
         (now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
     )
-    print(now.strftime(f"%Y.%m.%d.{modifier}"))
+    print(now.strftime(f"%-Y%m.%-d.{modifier}"))


### PR DESCRIPTION
SemVer has two rules that the previous scheme violates:

1. major/minor/patch numbers can't start with a leading 0. Changing `%d` to `%-d` removes the leading zero. I also applied it to the year just in case :):

```
>>> print(now.strftime(f"%Y.%m.%d"))
2023.09.01
>>> print(now.strftime(f"%Y.%-m.%-d"))
2023.9.1
```

2. there can't be four dot-separated sections of the version. In this PR, I merge the year and month into one field (with a leading zero on the month!) so the seconds is the "patch" version, like this:

```
>>> print(now.strftime(f"%-Y%m.%-d.{modifier}"))
202309.1.82922
```

I understand semantically poetry2nix isn't following semver, but I wonder if you're open to making the published tags semver parsable?