### PR TITLE
`httpcore`: `setuptools` -> `hatchling` in 0.18.0+

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7228,7 +7228,18 @@
     "setuptools"
   ],
   "httpcore": [
-    "setuptools"
+    {
+      "buildSystem": "hatch-fancy-pypi-readme",
+      "from": "0.18.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "0.18.0"
+    },
+    {
+      "buildSystem": "setuptools",
+      "until": "0.18.0"
+    }
   ],
   "httpie": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7229,16 +7229,16 @@
   ],
   "httpcore": [
     {
+      "buildSystem": "setuptools",
+      "until": "0.18.0"
+    },
+    {
       "buildSystem": "hatch-fancy-pypi-readme",
       "from": "0.18.0"
     },
     {
       "buildSystem": "hatchling",
       "from": "0.18.0"
-    },
-    {
-      "buildSystem": "setuptools",
-      "until": "0.18.0"
     }
   ],
   "httpie": [


### PR DESCRIPTION
Note that manually overriding the `buildInputs` in a flake actually results in:

```sh
last 10 log lines:
       > Executing pythonRemoveTestsDir
       > Finished executing pythonRemoveTestsDir
       > pythonCatchConflictsPhase
       > /nix/store/q2zpnf017gccs9w9mb0ikdqhkf0k5v82-catch_conflicts.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
       >   import pkg_resources
       > Found duplicated packages in closure for dependency 'hatchling':
       >   hatchling 1.18.0 (/nix/store/zjkajhjjz7wis9yvm3gwvphifx3hiav2-python3.10-hatchling-1.18.0/lib/python3.10/site-packages)
       >   hatchling 1.18.0 (/nix/store/2jy9c8hbk8v0rk45zv8680srs1jky977-python3.10-hatchling-1.18.0/lib/python3.10/site-packages)
       >
       > Package duplicates found in closure, see above. Usually this happens if two packages depend on different version of the same dependency.
```

so it's important that `build-systems.json` gets updated.