### PR TITLE
feat: Sort override build systems more strictly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
     - name: Check format
-      run: nix-shell --packages jq --pure --run 'diff --unified overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else .from end)" < overrides/build-systems.json)'
+      run: nix-shell --packages jq --pure --run 'diff --unified overrides/build-systems.json <(jq --from-file overrides/sort-build-systems.jq --raw-output --sort-keys < overrides/build-systems.json)'
 
   nixpkgs-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
     - name: Check format
-      run: nix-shell --packages jq --pure --run 'diff overrides/build-systems.json <(jq --raw-output --sort-keys < overrides/build-systems.json)'
+      run: nix-shell --packages jq --pure --run 'diff overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else null end)" < overrides/build-systems.json)'
 
   nixpkgs-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
     - name: Check format
-      run: nix-shell --packages jq --pure --run 'diff overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else null end)" < overrides/build-systems.json)'
+      run: nix-shell --packages jq --pure --run 'diff --unified overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else null end)" < overrides/build-systems.json)'
 
   nixpkgs-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: actions/checkout@v3
     - name: Check format
-      run: nix-shell --packages jq --pure --run 'diff --unified overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else null end)" < overrides/build-systems.json)'
+      run: nix-shell --packages jq --pure --run 'diff --unified overrides/build-systems.json <(jq --raw-output --sort-keys ".[] |= sort_by(if type==\"string\" then . else .from end)" < overrides/build-systems.json)'
 
   nixpkgs-fmt:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ To test with a specific channel:
 nix-build --expr 'with import <unstable> {}; callPackage ./tests/default.nix {}'
 ```
 
+To sort `overrides/build-systems.json` according to the [`sort-build-systems` job](.github/workflows/ci.yml), patch the source with the output of the "Check format" step, like this: `nix-shell [omitted] | patch -p0`.
+
 ## Contact
 We have a Matrix room at [#poetry2nix:blad.is](https://matrix.to/#/#poetry2nix:blad.is).
 

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7271,16 +7271,16 @@
   ],
   "httpx": [
     {
+      "buildSystem": "setuptools",
+      "until": "0.23.1"
+    },
+    {
       "buildSystem": "hatch-fancy-pypi-readme",
       "from": "0.23.1"
     },
     {
       "buildSystem": "hatchling",
       "from": "0.23.1"
-    },
-    {
-      "buildSystem": "setuptools",
-      "until": "0.23.1"
     }
   ],
   "httpx-auth": [
@@ -8148,6 +8148,14 @@
   ],
   "jsonschema": [
     {
+      "buildSystem": "setuptools",
+      "until": "4.6.0"
+    },
+    {
+      "buildSystem": "setuptools-scm",
+      "until": "4.6.0"
+    },
+    {
       "buildSystem": "hatch-fancy-pypi-readme",
       "from": "4.11.0"
     },
@@ -8158,14 +8166,6 @@
     {
       "buildSystem": "hatchling",
       "from": "4.6.0"
-    },
-    {
-      "buildSystem": "setuptools",
-      "until": "4.6.0"
-    },
-    {
-      "buildSystem": "setuptools-scm",
-      "until": "4.6.0"
     }
   ],
   "jsonschema-3": [
@@ -8223,12 +8223,12 @@
   ],
   "jupyter-core": [
     {
-      "buildSystem": "hatchling",
-      "from": "4.11.0"
-    },
-    {
       "buildSystem": "setuptools",
       "until": "4.11.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "4.11.0"
     }
   ],
   "jupyter-events": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -933,15 +933,15 @@
       "until": "23.1.0"
     },
     {
-      "buildSystem": "hatchling",
-      "from": "23.1.0"
-    },
-    {
       "buildSystem": "hatch-fancy-pypi-readme",
       "from": "23.1.0"
     },
     {
       "buildSystem": "hatch-vcs",
+      "from": "23.1.0"
+    },
+    {
+      "buildSystem": "hatchling",
       "from": "23.1.0"
     }
   ],
@@ -1226,7 +1226,7 @@
       "until": "23.1.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-fancy-pypi-readme",
       "from": "23.1.0"
     },
     {
@@ -1234,7 +1234,7 @@
       "from": "23.1.0"
     },
     {
-      "buildSystem": "hatch-fancy-pypi-readme",
+      "buildSystem": "hatchling",
       "from": "23.1.0"
     }
   ],
@@ -2243,7 +2243,7 @@
       "until": "22.10.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-fancy-pypi-readme",
       "from": "22.10.0"
     },
     {
@@ -2251,7 +2251,7 @@
       "from": "22.10.0"
     },
     {
-      "buildSystem": "hatch-fancy-pypi-readme",
+      "buildSystem": "hatchling",
       "from": "22.10.0"
     }
   ],
@@ -5521,11 +5521,11 @@
       "until": "3.9.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-vcs",
       "from": "3.9.0"
     },
     {
-      "buildSystem": "hatch-vcs",
+      "buildSystem": "hatchling",
       "from": "3.9.0"
     }
   ],
@@ -6403,11 +6403,11 @@
       "until": "0.19"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-vcs",
       "from": "0.19"
     },
     {
-      "buildSystem": "hatch-vcs",
+      "buildSystem": "hatchling",
       "from": "0.19"
     }
   ],
@@ -6417,11 +6417,11 @@
       "until": "0.19"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-vcs",
       "from": "0.19"
     },
     {
-      "buildSystem": "hatch-vcs",
+      "buildSystem": "hatchling",
       "from": "0.19"
     }
   ],
@@ -7321,11 +7321,11 @@
       "until": "4.6.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-vcs",
       "from": "4.6.0"
     },
     {
-      "buildSystem": "hatch-vcs",
+      "buildSystem": "hatchling",
       "from": "4.6.0"
     }
   ],
@@ -7620,11 +7620,11 @@
       "until": "2.0.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-vcs",
       "from": "2.0.0"
     },
     {
-      "buildSystem": "hatch-vcs",
+      "buildSystem": "hatchling",
       "from": "2.0.0"
     }
   ],
@@ -8304,11 +8304,11 @@
       "until": "4"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-jupyter-builder",
       "from": "4"
     },
     {
-      "buildSystem": "hatch-jupyter-builder",
+      "buildSystem": "hatchling",
       "from": "4"
     }
   ],
@@ -9543,11 +9543,11 @@
   ],
   "mkdocs-material": [
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-nodejs-version",
       "from": "8.5.3"
     },
     {
-      "buildSystem": "hatch-nodejs-version",
+      "buildSystem": "hatchling",
       "from": "8.5.3"
     },
     "setuptools"
@@ -10103,11 +10103,11 @@
       "until": "5.6.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-nodejs-version",
       "from": "5.6.0"
     },
     {
-      "buildSystem": "hatch-nodejs-version",
+      "buildSystem": "hatchling",
       "from": "5.6.0"
     }
   ],
@@ -12666,11 +12666,11 @@
       "until": "2.0.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-fancy-pypi-readme",
       "from": "2.0.0"
     },
     {
-      "buildSystem": "hatch-fancy-pypi-readme",
+      "buildSystem": "hatchling",
       "from": "2.0.0"
     }
   ],
@@ -16503,15 +16503,15 @@
       "until": "0.17.0"
     },
     {
-      "buildSystem": "hatchling",
-      "from": "0.17.0"
-    },
-    {
       "buildSystem": "hatch-fancy-pypi-readme",
       "from": "0.17.0"
     },
     {
       "buildSystem": "hatch-vcs",
+      "from": "0.17.0"
+    },
+    {
+      "buildSystem": "hatchling",
       "from": "0.17.0"
     },
     "cython"
@@ -16743,7 +16743,7 @@
       "until": "23.1.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-fancy-pypi-readme",
       "from": "23.1.0"
     },
     {
@@ -16751,7 +16751,7 @@
       "from": "23.1.0"
     },
     {
-      "buildSystem": "hatch-fancy-pypi-readme",
+      "buildSystem": "hatchling",
       "from": "23.1.0"
     }
   ],
@@ -17973,7 +17973,7 @@
       "until": "22.12.0"
     },
     {
-      "buildSystem": "hatchling",
+      "buildSystem": "hatch-fancy-pypi-readme",
       "from": "22.12.0"
     },
     {
@@ -17981,7 +17981,7 @@
       "from": "22.12.0"
     },
     {
-      "buildSystem": "hatch-fancy-pypi-readme",
+      "buildSystem": "hatchling",
       "from": "22.12.0"
     }
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -3221,11 +3221,11 @@
     "setuptools"
   ],
   "colorama": [
+    "setuptools",
     {
       "buildSystem": "hatchling",
       "from": "0.4.6"
-    },
-    "setuptools"
+    }
   ],
   "colorcet": [
     "setuptools"
@@ -3700,11 +3700,11 @@
     "setuptools"
   ],
   "dask": [
+    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    },
-    "setuptools"
+    }
   ],
   "dask-gateway": [
     "setuptools"
@@ -4198,11 +4198,11 @@
     "setuptools"
   ],
   "distributed": [
+    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    },
-    "setuptools"
+    }
   ],
   "distro": [
     "setuptools"
@@ -4653,11 +4653,11 @@
     "setuptools-scm"
   ],
   "docformatter": [
+    "setuptools",
     {
       "buildSystem": "poetry-core",
       "from": "1.5.0"
-    },
-    "setuptools"
+    }
   ],
   "docker": [
     "setuptools",
@@ -9496,11 +9496,11 @@
     "setuptools"
   ],
   "mkdocs": [
+    "setuptools",
     {
       "buildSystem": "hatchling",
       "from": "1.4.1"
-    },
-    "setuptools"
+    }
   ],
   "mkdocs-autorefs": [
     "pdm-pep517",
@@ -9542,6 +9542,7 @@
     "setuptools"
   ],
   "mkdocs-material": [
+    "setuptools",
     {
       "buildSystem": "hatch-nodejs-version",
       "from": "8.5.3"
@@ -9549,15 +9550,14 @@
     {
       "buildSystem": "hatchling",
       "from": "8.5.3"
-    },
-    "setuptools"
+    }
   ],
   "mkdocs-material-extensions": [
+    "setuptools",
     {
       "buildSystem": "hatchling",
       "from": "1.1"
-    },
-    "setuptools"
+    }
   ],
   "mkdocs-minify": [
     "setuptools"
@@ -10069,11 +10069,11 @@
     "setuptools"
   ],
   "nbclient": [
+    "setuptools",
     {
       "buildSystem": "hatchling",
       "from": "0.7.1"
-    },
-    "setuptools"
+    }
   ],
   "nbconflux": [
     "setuptools"
@@ -10369,6 +10369,7 @@
     "setuptools"
   ],
   "notebook-shim": [
+    "jupyter-packaging",
     {
       "buildSystem": "setuptools",
       "until": "0.2.0"
@@ -10376,8 +10377,7 @@
     {
       "buildSystem": "hatchling",
       "from": "0.2.0"
-    },
-    "jupyter-packaging"
+    }
   ],
   "notedown": [
     "setuptools"
@@ -11129,12 +11129,12 @@
     "setuptools"
   ],
   "pandas": [
+    "cython",
+    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    },
-    "cython",
-    "setuptools"
+    }
   ],
   "pandas-datareader": [
     "setuptools"
@@ -16494,6 +16494,7 @@
     "setuptools"
   ],
   "scikit-build": [
+    "cython",
     {
       "buildSystem": "setuptools",
       "until": "0.17.0"
@@ -16513,8 +16514,7 @@
     {
       "buildSystem": "hatchling",
       "from": "0.17.0"
-    },
-    "cython"
+    }
   ],
   "scikit-fmm": [
     "setuptools"
@@ -17532,11 +17532,11 @@
     "setuptools"
   ],
   "sqlglot": [
+    "setuptools",
     {
       "buildSystem": "setuptools-scm",
       "from": "13.0.2"
-    },
-    "setuptools"
+    }
   ],
   "sqlite-fts4": [
     "setuptools"
@@ -17931,11 +17931,11 @@
     "setuptools-scm"
   ],
   "tabulate": [
+    "setuptools",
     {
       "buildSystem": "setuptools-scm",
       "from": "0.9.0"
-    },
-    "setuptools"
+    }
   ],
   "tabview": [
     "setuptools"
@@ -18548,6 +18548,7 @@
     "setuptools"
   ],
   "traitlets": [
+    "setuptools",
     {
       "buildSystem": "flit-core",
       "until": "5.2.1"
@@ -18555,8 +18556,7 @@
     {
       "buildSystem": "hatchling",
       "from": "5.2.1"
-    },
-    "setuptools"
+    }
   ],
   "traits": [
     "setuptools"
@@ -19218,6 +19218,7 @@
     "setuptools"
   ],
   "urllib3": [
+    "setuptools",
     {
       "buildSystem": "flit-core",
       "until": "2.0.2"
@@ -19225,8 +19226,7 @@
     {
       "buildSystem": "hatchling",
       "from": "2.0.2"
-    },
-    "setuptools"
+    }
   ],
   "urlman": [
     "setuptools"
@@ -19407,6 +19407,7 @@
     "setuptools"
   ],
   "virtualenv": [
+    "cython",
     {
       "buildSystem": "setuptools-scm",
       "until": " 20.18"
@@ -19414,8 +19415,7 @@
     {
       "buildSystem": "hatch-vcs",
       "from": " 20.18"
-    },
-    "cython"
+    }
   ],
   "virtualenv-clone": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1292,8 +1292,8 @@
     "setuptools"
   ],
   "autoflake": [
-    "setuptools",
-    "hatchling"
+    "hatchling",
+    "setuptools"
   ],
   "autograd": [
     "setuptools"
@@ -3700,11 +3700,11 @@
     "setuptools"
   ],
   "dask": [
-    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    }
+    },
+    "setuptools"
   ],
   "dask-gateway": [
     "setuptools"
@@ -4198,11 +4198,11 @@
     "setuptools"
   ],
   "distributed": [
-    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    }
+    },
+    "setuptools"
   ],
   "distro": [
     "setuptools"
@@ -5250,8 +5250,8 @@
     "setuptools"
   ],
   "execnet": [
-    "hatchling",
     "hatch-vcs",
+    "hatchling",
     "setuptools",
     "setuptools-scm"
   ],
@@ -6893,8 +6893,8 @@
     "setuptools"
   ],
   "gunicorn": [
-    "setuptools",
-    "packaging"
+    "packaging",
+    "setuptools"
   ],
   "guppy3": [
     "setuptools"
@@ -7305,8 +7305,8 @@
     "setuptools"
   ],
   "human-readable": [
-    "hatchling",
-    "hatch-vcs"
+    "hatch-vcs",
+    "hatchling"
   ],
   "humanfriendly": [
     "setuptools"
@@ -8865,8 +8865,8 @@
     "setuptools"
   ],
   "llama-cpp-python": [
-    "setuptools",
-    "scikit-build"
+    "scikit-build",
+    "setuptools"
   ],
   "llfuse": [
     "cython",
@@ -9749,9 +9749,9 @@
     "setuptools-scm"
   ],
   "mpremote": [
-    "hatchling",
     "hatch-requirements-txt",
-    "hatch-vcs"
+    "hatch-vcs",
+    "hatchling"
   ],
   "mpv": [
     "setuptools"
@@ -11129,12 +11129,12 @@
     "setuptools"
   ],
   "pandas": [
-    "cython",
-    "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
-    }
+    },
+    "cython",
+    "setuptools"
   ],
   "pandas-datareader": [
     "setuptools"
@@ -11615,8 +11615,8 @@
     "setuptools"
   ],
   "pip-licenses": [
-    "setuptools",
-    "pytest-runner"
+    "pytest-runner",
+    "setuptools"
   ],
   "pip-requirements-parser": [
     "setuptools",
@@ -13290,8 +13290,8 @@
     "setuptools"
   ],
   "pylint-plugin-utils": [
-    "setuptools",
-    "poetry"
+    "poetry",
+    "setuptools"
   ],
   "pylint-venv": [
     "poetry-core"
@@ -14360,8 +14360,8 @@
     "setuptools-scm"
   ],
   "pytest-bdd": [
-    "setuptools",
-    "poetry-core"
+    "poetry-core",
+    "setuptools"
   ],
   "pytest-benchmark": [
     "setuptools"
@@ -14992,8 +14992,8 @@
     "setuptools"
   ],
   "python-multipart": [
-    "setuptools",
-    "hatchling"
+    "hatchling",
+    "setuptools"
   ],
   "python-mystrom": [
     "setuptools"
@@ -15171,8 +15171,8 @@
     "setuptools"
   ],
   "python-ubersmithclient": [
-    "setuptools",
-    "pbr"
+    "pbr",
+    "setuptools"
   ],
   "python-uinput": [
     "setuptools"
@@ -16494,7 +16494,6 @@
     "setuptools"
   ],
   "scikit-build": [
-    "cython",
     {
       "buildSystem": "setuptools",
       "until": "0.17.0"
@@ -16514,7 +16513,8 @@
     {
       "buildSystem": "hatch-vcs",
       "from": "0.17.0"
-    }
+    },
+    "cython"
   ],
   "scikit-fmm": [
     "setuptools"
@@ -17532,11 +17532,11 @@
     "setuptools"
   ],
   "sqlglot": [
-    "setuptools",
     {
       "buildSystem": "setuptools-scm",
       "from": "13.0.2"
-    }
+    },
+    "setuptools"
   ],
   "sqlite-fts4": [
     "setuptools"
@@ -17941,8 +17941,8 @@
     "setuptools"
   ],
   "tacacs-plus": [
-    "setuptools",
-    "pytest-runner"
+    "pytest-runner",
+    "setuptools"
   ],
   "tadasets": [
     "setuptools"

--- a/overrides/sort-build-systems.jq
+++ b/overrides/sort-build-systems.jq
@@ -7,6 +7,8 @@
     else
         # Sort entries with an `until` field above entries with a `from` field
         .from,
-        .until
+        .until,
+        # Sort build systems with the same `from` and `until` values
+        .buildSystem
     end
 )

--- a/overrides/sort-build-systems.jq
+++ b/overrides/sort-build-systems.jq
@@ -1,8 +1,11 @@
+# Sort each entry in the top-level dictionary
 .[] |= sort_by(
     if type == "string"
     then
+        # Sort string overrides alphabetically
         .
     else
+        # Sort entries with an `until` field above entries with a `from` field
         .from
     end
 )

--- a/overrides/sort-build-systems.jq
+++ b/overrides/sort-build-systems.jq
@@ -1,5 +1,7 @@
 # Sort each entry in the top-level dictionary
 .[] |= sort_by(
+    # Put all strings before objects
+    type == "object",
     if type == "string"
     then
         # Sort string overrides alphabetically

--- a/overrides/sort-build-systems.jq
+++ b/overrides/sort-build-systems.jq
@@ -6,6 +6,7 @@
         .
     else
         # Sort entries with an `until` field above entries with a `from` field
-        .from
+        .from,
+        .until
     end
 )

--- a/overrides/sort-build-systems.jq
+++ b/overrides/sort-build-systems.jq
@@ -1,0 +1,8 @@
+.[] |= sort_by(
+    if type == "string"
+    then
+        .
+    else
+        .from
+    end
+)


### PR DESCRIPTION
Closes #1320.

[`jq` does not yet support sorting by locale](https://github.com/jqlang/jq/issues/2218), so there are some slightly awkward sorts like "hatch-vcs" before "hatchling".

FYI @moonshxne @cpcloud