### PR TITLE
build-systems: add override for textual-fastdatatable

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -18239,6 +18239,10 @@
     "poetry-core",
     "setuptools"
   ],
+  "textual-fastdatatable": [
+    "poetry-core",
+    "setuptools"
+  ],
   "textual-textarea": [
     "poetry-core",
     "setuptools"


### PR DESCRIPTION
Similar to the other textual-* packages, seems low value to add a test for each. I'm inclined to just merge this directly but I'll defer to my co-maintainers.