### PR TITLE
refactor(treefmt): use builtin treefmt programs

### DIFF
--- a/dev/treefmt.nix
+++ b/dev/treefmt.nix
@@ -1,37 +1,8 @@
-{ pkgs, ... }: {
+{
   # Used to find the project root
   projectRootFile = "flake.lock";
 
-  settings.formatter = {
-    nix = {
-      command = "sh";
-      options = [
-        "-eucx"
-        ''
-          ${pkgs.lib.getExe pkgs.deadnix} --edit "$@"
-
-          for i in "$@"; do
-            ${pkgs.lib.getExe pkgs.statix} fix "$i"
-          done
-
-          ${pkgs.lib.getExe pkgs.nixpkgs-fmt} "$@"
-        ''
-        "--"
-      ];
-      includes = [ "*.nix" ];
-      excludes = [ ];
-    };
-
-    python = {
-      command = "sh";
-      options = [
-        "-eucx"
-        ''
-          ${pkgs.lib.getExe pkgs.python3.pkgs.black} "$@"
-        ''
-        "--" # this argument is ignored by bash
-      ];
-      includes = [ "*.py" ];
-    };
-  };
+  programs.deadnix.enable = true;
+  programs.statix.enable = true;
+  programs.black.enable = true;
 }


### PR DESCRIPTION
No need to manually pass things around and invoke programs using `sh`, treefmt already has programs for the tools we use.