### PR TITLE
overrides.pyqt6: Only do autoPatchelf stuff on wheels

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2522,7 +2522,7 @@ lib.composeManyExtensions [
               postUnpack = ''
                 export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
               '';
-              preFixup = ''
+              preFixup = lib.optionalString isWheel ''
                 addAutoPatchelfSearchPath ${self.pyqt6-qt6}/${self.python.sitePackages}/PyQt6
               '';
             });


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
