### PR TITLE
overrides: add build systems

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -1729,6 +1729,15 @@
   "azure-batch": [
     "setuptools"
   ],
+  "azure-cli": [
+    "setuptools"
+  ],
+  "azure-cli-core": [
+    "setuptools"
+  ],
+  "azure-cli-telemetry": [
+    "setuptools"
+  ],
   "azure-common": [
     "setuptools"
   ],
@@ -1796,6 +1805,9 @@
     "setuptools"
   ],
   "azure-mgmt-appconfiguration": [
+    "setuptools"
+  ],
+  "azure-mgmt-appcontainers": [
     "setuptools"
   ],
   "azure-mgmt-applicationinsights": [
@@ -12052,6 +12064,9 @@
     "pbr",
     "setuptools"
   ],
+  "oschmod": [
+    "setuptools"
+  ],
   "oscpy": [
     "setuptools"
   ],
@@ -13363,7 +13378,16 @@
   "pulumi-command": [
     "setuptools"
   ],
+  "pulumi-gcp": [
+    "setuptools"
+  ],
+  "pulumi-kubernetes": [
+    "setuptools"
+  ],
   "pulumi-random": [
+    "setuptools"
+  ],
+  "pulumi-tls": [
     "setuptools"
   ],
   "pure-cdb": [
@@ -13808,6 +13832,9 @@
     "setuptools"
   ],
   "pycomfoconnect": [
+    "setuptools"
+  ],
+  "pycomposefile": [
     "setuptools"
   ],
   "pycontracts": [


### PR DESCRIPTION
Multiple packages that require setuptools all related to pulumi

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
