### PR TITLE
fix: use pep508.parseString for requiredPkgs parsing 

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -45,7 +45,7 @@ let
       missingBuildBackendError = "No build-system.build-backend section in pyproject.toml. "
         + "Add such a section as described in https://python-poetry.org/docs/pyproject/#poetry-and-pep-517";
       requires = lib.attrByPath [ "build-system" "requires" ] (throw missingBuildBackendError) pyProject;
-      requiredPkgs = builtins.map (n: lib.elemAt (builtins.match "([^!=<>~[]+).*" n) 0) requires;
+      requiredPkgs = builtins.map (n: (pyproject-nix.lib.pep508.parseString n).name) requires;
     in
     builtins.map (drvAttr: pythonPackages.${drvAttr} or (throw "unsupported build system requirement ${drvAttr}")) requiredPkgs;
 


### PR DESCRIPTION
PEP508 supports `requires` lines that have leading/trailing spaces, such
as:

    requires = ["poetry-core >=1.7.0"]

Poetry apparently handles this fine, but poetry2nix doesn't. This commit
uses proper parsing with the pep508 library.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
