### PR TITLE
overrides: add setuptools to pyxis build

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13574,9 +13574,6 @@
   "py-vapid": [
     "setuptools"
   ],
-  "pyxis": [
-    "setuptools"
-  ],
   "py-zabbix": [
     "setuptools"
   ],
@@ -17068,6 +17065,9 @@
     "setuptools"
   ],
   "pyxiaomigateway": [
+    "setuptools"
+  ],
+  "pyxis": [
     "setuptools"
   ],
   "pyxl3": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -13574,6 +13574,9 @@
   "py-vapid": [
     "setuptools"
   ],
+  "pyxis": [
+    "setuptools"
+  ],
   "py-zabbix": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -3962,6 +3962,9 @@
   "customerio": [
     "setuptools"
   ],
+  "cvat-sdk": [
+    "setuptools"
+  ],
   "cvxopt": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -20603,6 +20603,9 @@
   "tusker": [
     "poetry"
   ],
+  "tuspy": [
+    "setuptools"
+  ],
   "tuya-iot-py-sdk": [
     "setuptools"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
