### PR TITLE
Add overrides for pygls and python-lsp-ruff

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16427,6 +16427,9 @@
     "setuptools",
     "setuptools-scm"
   ],
+  "python-lsp-ruff": [
+    "setuptools"
+  ],
   "python-lsp-server": [
     "setuptools",
     "setuptools-scm"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14302,6 +14302,7 @@
     "setuptools"
   ],
   "pygls": [
+    "poetry",
     "setuptools",
     "setuptools-scm"
   ],


### PR DESCRIPTION
While building a small project, I was hit with

    error: builder for '/nix/store/wqnn0z60fli4bsxhg98cpqdr2w0w9b6q-python3.11-python-lsp-ruff-1.6.0.drv' failed with exit code 2;
           last 10 log lines:
           >   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
           >   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
           >   File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
           >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
           >   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
           >   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
           >   File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
           > ModuleNotFoundError: No module named 'setuptools'
           >
           >
           For full logs, run 'nix log /nix/store/wqnn0z60fli4bsxhg98cpqdr2w0w9b6q-python3.11-python-lsp-ruff-1.6.0.drv'.
    error: 1 dependencies of derivation '/nix/store/s38y0qwc2qqj7kknc3rld3yqcadwq6rd-nix-shell-env.drv' failed to build

and

    error: builder for '/nix/store/6bnicdrl0vn5fda5h3vhlb38mzvsbwcb-python3.11-pygls-1.1.2.drv' failed with exit code 2;
           last 10 log lines:
           >   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
           >   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
           >   File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
           >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
           >   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
           >   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
           >   File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
           > ModuleNotFoundError: No module named 'poetry'
           >
           >
           For full logs, run 'nix log /nix/store/6bnicdrl0vn5fda5h3vhlb38mzvsbwcb-python3.11-pygls-1.1.2.drv'.
    error: 1 dependencies of derivation '/nix/store/j02qff2ibcr9fywq2h7q1d9biwcjj5b8-python3.11-ruff-lsp-0.0.45.drv' failed to build
    error: 1 dependencies of derivation '/nix/store/4arc83xymd9z8pr3j3cx138mmcxppgx4-nix-shell-env.drv' failed to build

Adding appropriate overrides fixed them, so trying to upstream them sounds like the right thing to do.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"