### PR TITLE
overrides: multidict -> remove pip dependency

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10814,7 +10814,6 @@
     "setuptools"
   ],
   "multidict": [
-    "pip",
     "setuptools"
   ],
   "multihash": [


### PR DESCRIPTION
This appears to have been added in #1329 without comment, but is now causing a duplicate dependency failure for me:

```console
python3.11-multidict> Found duplicated packages in closure for dependency 'pip':
python3.11-multidict>   pip 23.2.1 (/nix/store/slhj69him45n2pck7wkknnffi4ay0jy0-python3.11-pip-23.2.1/lib/python3.11/site-packages/pip-23.2.1.dist-info)
python3.11-multidict>   pip 23.2.1 (/nix/store/rqch5axq9ky53cny22zwyvq93g0w68jn-python3.11-pip-23.2.1/lib/python3.11/site-packages/pip-23.2.1.dist-info)
python3.11-multidict> Package duplicates found in closure, see above. Usually this happens if two packages depend on different version of the same dependency.
```

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
