### PR TITLE
pip-build-hook: enable validation of build dependencies

### DIFF
--- a/hooks/pip-build-hook.sh
+++ b/hooks/pip-build-hook.sh
@@ -16,6 +16,7 @@ pipBuildPhase() {
        --no-clean \
        --no-build-isolation \
        --wheel-dir dist \
+       --check-build-dependencies \
        $pipBuildFlags .
     echo "Finished creating a wheel..."
 

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -21194,7 +21194,11 @@
     "setuptools"
   ],
   "uri-template": [
-    "setuptools"
+    "setuptools",
+    {
+      "buildSystem": "setuptools-scm",
+      "from": "1.3.0"
+    }
   ],
   "uritemplate": [
     "setuptools"

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1245,7 +1245,8 @@ lib.composeManyExtensions [
           # jupyterlab?)
           postPatch = ''
             substituteInPlace pyproject.toml \
-              --replace ', "jupyterlab~=3.0"' ""
+              --replace ', "jupyterlab~=3.0"' "" \
+              --replace ', "jupyterlab~=4.0"' ""
           '';
         }
       );

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1886,7 +1886,12 @@ lib.composeManyExtensions [
 
         # For OSX, we need to add a dependency on libcxx, which provides
         # `complex.h` and other libraries that pandas depends on to build.
-        postPatch = lib.optionalString (!(old.src.isWheel or false) && stdenv.isDarwin) ''
+        postPatch = ''
+          if [ -f pyproject.toml ]; then
+            substituteInPlace pyproject.toml \
+              --replace 'meson-python==0.13.1' 'meson-python'
+          fi
+        '' + lib.optionalString (!(old.src.isWheel or false) && stdenv.isDarwin) ''
           if [ -f setup.py ]; then
             cpp_sdk="${lib.getDev pkgs.libcxx}/include/c++/v1";
             echo "Adding $cpp_sdk to the setup.py common_include variable"


### PR DESCRIPTION
Per https://pip.pypa.io/en/stable/cli/pip_wheel/#cmdoption-check-build-dependencies

It turns out that unlike pypa, pip only checks build dependencies if it is told to.

This makes the missing build dependencies a lot clearer, since it immediately lists all missing dependencies rather than fail when it can't find them.

----

This change turns out to have surfaced a few hidden bugs with existing test cases, additional commits fix these issues.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
