### PR TITLE
Add build-systems override for rich-click

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17764,6 +17764,9 @@
   "rich-argparse-plus": [
     "flit"
   ],
+  "rich-click": [
+    "setuptools"
+  ],
   "rich-pixels": [
     "poetry-core"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
