### PR TITLE
overrides: remove pip from opencv-python, opencv-python-headless

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11747,16 +11747,34 @@
     "setuptools"
   ],
   "opencv-python": [
-    "cmake",
-    "pip",
-    "scikit-build",
-    "setuptools"
+    {
+      "buildSystem": "cmake"
+    },
+    {
+      "buildSystem": "pip",
+      "until": "4.7.0.72"
+    },
+    {
+      "buildSystem": "scikit-build"
+    },
+    {
+      "buildSystem": "setuptools"
+    }
   ],
   "opencv-python-headless": [
-    "cmake",
-    "pip",
-    "scikit-build",
-    "setuptools"
+    {
+      "buildSystem": "cmake"
+    },
+    {
+      "buildSystem": "pip",
+      "until": "4.7.0.72"
+    },
+    {
+      "buildSystem": "scikit-build"
+    },
+    {
+      "buildSystem": "setuptools"
+    }
   ],
   "opencv4": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11766,10 +11766,6 @@
       "buildSystem": "cmake"
     },
     {
-      "buildSystem": "pip",
-      "until": "4.7.0.72"
-    },
-    {
       "buildSystem": "scikit-build"
     },
     {


### PR DESCRIPTION
Pip was added as a dependency of the opencv-python project itself in release 4.8.0.74 ([commit](https://github.com/opencv/opencv-python/commit/d82d7c2befd1e830287e8c1c125fdab8462836c2)).

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
