### PR TITLE
overrides: add pydevd-pycharm

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14029,6 +14029,9 @@
   "pydevd-odoo": [
     "setuptools"
   ],
+  "pydevd-pycharm": [
+    "setuptools"
+  ],
   "pydevtool": [
     "setuptools"
   ],


### PR DESCRIPTION
Note: I tried testing this in my project by using my branch rather than upstream, but it seemed to have no effect. Since this is very similar to other overrides, I'm just going to assume that was an issue with the way I was testing the override.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
