### PR TITLE
overrides: add cargo hash for bcrypt 4.1.1

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -315,6 +315,7 @@ lib.composeManyExtensions [
           getCargoHash = version: {
             "4.0.0" = "sha256-HvfRLyUhlXVuvxWrtSDKx3rMKJbjvuiMcDY6g+pYFS0=";
             "4.0.1" = "sha256-lDWX69YENZFMu7pyBmavUZaalGvFqbHSHfkwkzmDQaY=";
+            "4.1.1" = "sha256-QYg1+DsZEdXB74vuS4SFvV0n5GXkuwHkOS9j1ogSTjA=";
           }.${version} or (
             lib.warn "Unknown bcrypt version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
closes #1436
