### PR TITLE
overrides: add hash for cryptography 41.0.6

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -541,6 +541,7 @@ lib.composeManyExtensions [
             "41.0.3" = "sha256-LQu7waympGUs+CZun2yDQd2gUUAgyisKBG5mddrfSo0=";
             "41.0.4" = "sha256-oXR8yBUgiA9BOfkZKBJneKWlpwHB71t/74b/5WpiKmw=";
             "41.0.5" = "sha256-ABCK144//RUJ3AksFHEgqC+kHvoHl1ifpVuqMTkGNH8=";
+            "41.0.6" = "sha256-E7O0035BnJfTQeZNAN3Oz0fMbfj45htvnK8AHOzfdcY=";
             "41.0.7" = "sha256-VeZhKisCPDRvmSjGNwCgJJeVj65BZ0Ge+yvXbZw86Rw=";
           }.${version} or (
             lib.warn "Unknown cryptography version: '${version}'. Please update getCargoHash." lib.fakeHash


### PR DESCRIPTION
```
trace: warning: Unknown cryptography version: '41.0.6'. Please update getCargoHash.
error: hash mismatch in fixed-output derivation '/nix/store/b5j2nrwkffbxmjgm9d7y2hddx7j4ygvc-cryptography-41.0.6-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-E7O0035BnJfTQeZNAN3Oz0fMbfj45htvnK8AHOzfdcY=
```