### PR TITLE
fix(pytorch-lightning): disable unpackPhase override

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2432,22 +2432,11 @@ lib.composeManyExtensions [
         '';
       });
 
-
       pytoml = super.pytoml.overridePythonAttrs (
         _old: {
           doCheck = false;
         }
       );
-
-      pytorch-lightning = super.pytorch-lightning.override {
-        unpackPhase = ''
-          # $src remains a gzipped tarball otherwise.
-          mkdir -p tmp
-          tar xvf $src --directory=tmp
-          mv tmp/pytorch-lightning*/* .
-          rm -rf tmp
-        '';
-      };
 
       pyqt5 =
         let


### PR DESCRIPTION
There are default overrides for  `pytorch-lightning`  that attempt to handle what must have previously been something like a nested tarball. I removed these and what previously resulted in

```bash
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
tar: This does not look like a tar archive
```

during installation proceeded as expected. This is at least true when I source the boundaries of the `[1.9.4 2.1.3]` version range in a test flake on Darwin aarch64 and Linux x86_64 systems. I am posting this PR to mark the issue and discuss the necessity of retaining these `unpackPhase` customizations with version guards for backward compatibility versus removing them altogether.

I could add such guards if I knew where things changed, but I didn't manage to bisect where that is in the pytorch-lightning release history after experimenting with `1.9.4` and sporadically downloading a few of the very early source distributions from PyPI to inspect their structure.

Since the `unpackPhase` was added in [poetry2nix #786 Oct 31 2022](https://github.com/nix-community/poetry2nix/pull/786) the change should presumably be somewhere between the `pytorch-lightning` release prior to that [Sep 22 2022 1.7.7](https://pypi.org/project/pytorch-lightning/1.7.7/#files) and the oldest one I checked manually from [March 2 2023 in 1.9.4](https://pypi.org/project/pytorch-lightning/1.9.4/#files).

Alternatively, there may have been a higher-level change in how the source tarball's are handled rendering this unpackPhase unnecessary, even for older versions.