### PR TITLE
overrides/matplotlib: only add setuptools-scm-git-archive for older versions

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1452,6 +1452,7 @@ lib.composeManyExtensions [
             pkg-config
           ] ++ lib.optionals (lib.versionAtLeast super.matplotlib.version "3.5.0") [
             self.setuptools-scm
+          ] ++ lib.optionals (lib.versionOlder super.matplotlib.version "3.6.0") [
             self.setuptools-scm-git-archive
           ];
 


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
