### PR TITLE
Update hashes for ruff; fix injection vulnerabilities in paired script

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2965,11 +2965,15 @@ lib.composeManyExtensions [
         let
           # generated with
           # curl https://api.github.com/repos/astral-sh/ruff/releases | \
-          #   jq -r '.[].tag_name'  | \
-          #   xargs -I {version} sh -c \
-          #     'nix_prefetch=$(nix-prefetch-github astral-sh ruff --rev {version}); \
-          #      echo "\"$(echo {version} | sed 's/^v//')\" = \"$(echo $nix_prefetch | jq -r .sha256)\";"'
+          #   jq -r '.[].tag_name' | tr '\n' '\0' | xargs -0 sh -c '
+          #     for version in "$@"; do
+          #       nix_prefetch=$(nix-prefetch-github astral-sh ruff --rev "$version") || exit;
+          #       echo "\"${version#v}\" = \"$(echo "$nix_prefetch" | jq -r ".sha256 // .hash")\";"
+          #     done' _
           getRepoHash = version: {
+            "0.1.11" = "sha256-yKb74GADeALai4qZ/+dR6u/QzKQF5404+YJKSYU/oFU=";
+            "0.1.10" = "sha256-uFbqL4hFVpH12gSCUmib+Q24cApWKtGa8mRmKFUTQok=";
+            "0.1.9" = "sha256-Dtzzh4ersTLbAsG06d8dJa1rFgsruicU0bXl5IAUZMg=";
             "0.1.8" = "sha256-zf2280aSmGstcgxoU/IWtdtdWExvdKLBNh4Cn5tC1vU";
             "0.1.7" = "sha256-Al256/8A/efLrf97xCwEocwgs3ngPnEAmkfcLWdlkTw=";
             "0.1.6" = "sha256-EX1tXe8KlwjrohzgzKDeJP0PjfKw8+lnQ7eg9PAUAfQ=";


### PR DESCRIPTION
Yes, it's unlikely that ruff's maintainer (or an attacker who has broken into or MITM'd github's API) would try to attack us through malicious tag names, but why allow the possibility?

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [X] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
