### PR TITLE
overrides: add crewAI and its missing dependencies

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -3871,6 +3871,9 @@
   "credstash": [
     "setuptools"
   ],
+  "crewai": [
+    "poetry"
+  ],
   "crispy-bootstrap5": [
     "setuptools"
   ],
@@ -8936,6 +8939,9 @@
     "setuptools"
   ],
   "jsonpath-ng": [
+    "setuptools"
+  ],
+  "jsonpath-python": [
     "setuptools"
   ],
   "jsonpath-rw": [
@@ -16495,6 +16501,9 @@
     "pbr",
     "setuptools"
   ],
+  "python-iso639": [
+    "setuptools"
+  ],
   "python-izone": [
     "setuptools",
     "setuptools-scm"
@@ -16902,6 +16911,9 @@
   "pytile": [
     "poetry-core",
     "setuptools"
+  ],
+  "pytils": [
+    "poetry-core"
   ],
   "pytimeparse": [
     "setuptools"
@@ -20503,6 +20515,9 @@
     "poetry-core",
     "setuptools"
   ],
+  "tools": [
+    "setuptools"
+  ],
   "toolz": [
     "setuptools"
   ],
@@ -21274,6 +21289,12 @@
     "setuptools"
   ],
   "unrardll": [
+    "setuptools"
+  ],
+  "unstructured": [
+    "setuptools"
+  ],
+  "unstructured-client": [
     "setuptools"
   ],
   "untangle": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9407,6 +9407,9 @@
   "langchain": [
     "poetry-core"
   ],
+  "langchain-community": [
+    "poetry-core"
+  ],
   "langchain-core": [
     "poetry-core"
   ],


### PR DESCRIPTION
This is what I need to get https://github.com/joaomdmoura/crewAI-examples/tree/main/trip_planner running,
an example project for https://github.com/joaomdmoura/crewAI, except for the following override:

```
overrides = p2n.defaultPoetryOverrides.extend (self: super: {
  unstructured = super.unstructured.overridePythonAttrs (old: rec {
    src = super.pkgs.fetchFromGitHub {
      owner = "Unstructured-IO";
      repo = "unstructured";
      rev = "refs/tags/${old.version}";
      sha256 = "sha256-kpT/rcAFlPmDVuayVgW9WHI9MT+2R6AC8Z/8+vDHYVw=";
    };
  });
});
};
```
That overlay was required because the source distribution for `unstructured` is missing a bunch of files.
I thought getting the overlay into a state that could be committed here wasn't worth it.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
