### PR TITLE
fix(types-ujson): specify setuptools as a build system for types-ujson.

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -21103,6 +21103,9 @@
   "types-typed-ast": [
     "setuptools"
   ],
+  "types-ujson": [
+    "setuptools"
+  ],
   "types-urllib3": [
     "setuptools"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
