### PR TITLE
overrides: add ninja-python, alabaster and quantile-python

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -656,6 +656,7 @@
     "setuptools"
   ],
   "alabaster": [
+    "flit-core",
     "setuptools"
   ],
   "aladdin-connect": [
@@ -11383,10 +11384,12 @@
     "setuptools"
   ],
   "ninja": [
-    "flit-core"
+    "flit-core",
+    "setuptools"
   ],
   "ninja-python": [
-    "flit-core"
+    "flit-core",
+    "scikit-build"
   ],
   "nipy": [
     "cython",
@@ -17417,6 +17420,9 @@
     "setuptools"
   ],
   "quandl": [
+    "setuptools"
+  ],
+  "quantile-python": [
     "setuptools"
   ],
   "quantiphy": [


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
