### PR TITLE
fix(overrides): Use cython3 for pandas>=2.2.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -237,7 +237,11 @@ lib.makeScope pkgs.newScope (self: {
             (self: super: lib.attrsets.mapAttrs
               (
                 name: value:
-                  if lib.isDerivation value && self.hasPythonModule value && (normalizePackageName name) != name
+                  if
+                    lib.isDerivation value &&
+                    self.hasPythonModule value &&
+                    (normalizePackageName name) != name &&
+                    (!lib.hasPrefix "${normalizePackageName value.pname}_" name)
                   then null
                   else value
               )

--- a/known-build-systems.json
+++ b/known-build-systems.json
@@ -5,6 +5,7 @@
   "flit-core",
   "pbr",
   "cython",
+  "cython3",
   "hatchling",
   "hatch-vcs",
   "setuptools",

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -12380,13 +12380,20 @@
     "setuptools"
   ],
   "pandas": [
-    "cython",
     "meson-python",
     "oldest-supported-numpy",
     "setuptools",
     {
       "buildSystem": "versioneer",
       "from": "2.0.0"
+    },
+    {
+      "buildSystem": "cython",
+      "until": "2.2.0"
+    },
+    {
+      "buildSystem": "cython3",
+      "from": "2.2.0"
     }
   ],
   "pandas-datareader": [

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -10,6 +10,13 @@ let
     , extraAttrs ? [ ]
     }:
     let
+      getBuildSystem = buildSystem:
+        if buildSystem == "cython" then
+          self.python.pythonForBuild.pkgs.cython
+        else if buildSystem == "cython3" then
+          self.python.pythonForBuild.pkgs.cython_3
+        else
+          self.${buildSystem};
       buildSystem =
         if builtins.isAttrs attr then
           let
@@ -23,15 +30,11 @@ let
                 lib.versionOlder drv.version attr.until
               else
                 true;
-            intendedBuildSystem =
-              if attr.buildSystem == "cython" then
-                self.python.pythonForBuild.pkgs.cython
-              else
-                self.${attr.buildSystem};
+            intendedBuildSystem = getBuildSystem attr.buildSystem;
           in
           if fromIsValid && untilIsValid then intendedBuildSystem else null
         else
-          if attr == "cython" then self.python.pythonForBuild.pkgs.cython else self.${attr};
+          getBuildSystem attr;
     in
     if (attr == "flit-core" || attr == "flit" || attr == "hatchling") && !self.isPy3k then drv
     else if drv == null then null


### PR DESCRIPTION
`pandas>=2.2.0` now requires Cython 3. Not sure if this is the right approach here.

---

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
