### PR TITLE
overrides: add hash for cryptography 42.0.1

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -549,6 +549,7 @@ lib.composeManyExtensions [
             "41.0.5" = "sha256-ABCK144//RUJ3AksFHEgqC+kHvoHl1ifpVuqMTkGNH8=";
             "41.0.6" = "sha256-E7O0035BnJfTQeZNAN3Oz0fMbfj45htvnK8AHOzfdcY=";
             "41.0.7" = "sha256-VeZhKisCPDRvmSjGNwCgJJeVj65BZ0Ge+yvXbZw86Rw=";
+            "42.0.1" = "sha256-Kq/TSoI1cm9Pwg5CulNlAADmxdq0oWbgymHeMErUtcE=";
             "42.0.2" = "sha256-jw/FC5rQO77h6omtBp0Nc2oitkVbNElbkBUduyprTIc=";
             "42.0.3" = "sha256-QBZLGXdQz2WIBlAJM+yBk1QgmfF4b3G0Y1I5lZmAmtU=";
           }.${version} or (


### PR DESCRIPTION
```
error: hash mismatch in fixed-output derivation '/nix/store/9h03g10i0nkj07w20nxphj7r5fylb8i3-cryptography-42.0.1-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-Kq/TSoI1cm9Pwg5CulNlAADmxdq0oWbgymHeMErUtcE=
error: 1 dependencies of derivation '/nix/store/8amjb26dh5qypj11gxl3mrmp8d2aac4y-python3.11-cryptography-42.0.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/izmjj6vk5mw5cbipalq4acy4x7326r5q-python3.11-pyjwt-2.8.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/nzy0p1k4q4y2p7wgxsi6vfi7vlwby9m2-python3.11-django-allauth-0.60.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1idzc59zvwabnih9ml3fbbr8s9vdpyfy-nix-shell-env.drv' failed to build
```