### PR TITLE
fix(m2crypto): Update missing dependencies for M2Crypto

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1381,6 +1381,13 @@ lib.composeManyExtensions [
         }
       );
 
+      m2crypto = super.m2crypto.overridePythonAttrs (
+        old: {
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.swig ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.openssl ];
+        }
+      );
+
       markdown-it-py = super.markdown-it-py.overridePythonAttrs (
         old: {
           propagatedBuildInputs = builtins.filter (i: i.pname != "mdit-py-plugins") old.propagatedBuildInputs;


### PR DESCRIPTION
m2crypto needs swig at build time and openssl libs at run time.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst?ref_type=heads#id1
