### PR TITLE
Adjust for renaming of `pythonForBuild` to `pythonOnBuildForHost`

### DIFF
--- a/hooks/default.nix
+++ b/hooks/default.nix
@@ -1,11 +1,11 @@
 { python, stdenv, makeSetupHook, pkgs, lib }:
 let
-  inherit (python) pythonForBuild;
-  inherit (pythonForBuild.pkgs) callPackage;
-  pythonInterpreter = pythonForBuild.interpreter;
+  pythonOnBuildForHost = python.pythonOnBuildForHost or python.pythonForBuild;
+  inherit (pythonOnBuildForHost.pkgs) callPackage;
+  pythonInterpreter = pythonOnBuildForHost.interpreter;
   pythonSitePackages = python.sitePackages;
 
-  nonOverlayedPython = pkgs.python3.pythonForBuild.withPackages (ps: [ ps.tomlkit ]);
+  nonOverlayedPython = (pkgs.python3.pythonOnBuildForHost or pkgs.python3.pythonForBuild).withPackages (ps: [ ps.tomlkit ]);
   makeRemoveSpecialDependenciesHook =
     { fields
     , kind

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -25,13 +25,13 @@ let
                 true;
             intendedBuildSystem =
               if attr.buildSystem == "cython" then
-                self.python.pythonForBuild.pkgs.cython
+                (self.python.pythonOnBuildForHost or self.python.pythonForBuild).pkgs.cython
               else
                 self.${attr.buildSystem};
           in
           if fromIsValid && untilIsValid then intendedBuildSystem else null
         else
-          if attr == "cython" then self.python.pythonForBuild.pkgs.cython else self.${attr};
+          if attr == "cython" then (self.python.pythonOnBuildForHost or self.python.pythonForBuild).pkgs.cython else self.${attr};
     in
     if (attr == "flit-core" || attr == "flit" || attr == "hatchling") && !self.isPy3k then drv
     else if drv == null then null
@@ -101,7 +101,7 @@ lib.composeManyExtensions [
     let
       inherit (self.python) stdenv;
       inherit (pkgs.buildPackages) pkg-config;
-      pyBuildPackages = self.python.pythonForBuild.pkgs;
+      pyBuildPackages = (self.python.pythonOnBuildForHost or self.python.pythonForBuild).pkgs;
 
       selectQt5 = version:
         let
@@ -129,7 +129,7 @@ lib.composeManyExtensions [
         qtxmlpatterns
       ];
 
-      bootstrappingBase = pkgs.${self.python.pythonAttr}.pythonForBuild.pkgs;
+      bootstrappingBase = (pkgs.${self.python.pythonAttr}.pythonOnBuildForHost or pkgs.${self.python.pythonAttr}.pythonForBuild).pkgs;
     in
 
     {


### PR DESCRIPTION
The upstream Nixpkgs renamed `pythonForBuild` to `pythonOnBuildForHost` and made `pythonForBuild` emit warnings: NixOS/nixpkgs#265764.  Adjust the poetry2nix code to avoid warnings with the new version, while still keeping compatibility with the old one.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
