### PR TITLE
fix(python-firebase): Add "setuptools" to build-systems.json

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16462,6 +16462,9 @@
   "python-fedora": [
     "setuptools"
   ],
+  "python-firebase": [
+    "setuptools"
+  ],
   "python-flirt": [
     "setuptools"
   ],


### PR DESCRIPTION
python-firebase needs `setuptools`, see here: https://github.com/ozgur/python-firebase/blob/0d79d7609844569ea1cec4ac71cb9038e834c355/setup.py#L5

I hope I added it correctly!

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
