### PR TITLE
overrides: Fix marshmallow and twisted

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10147,6 +10147,7 @@
   ],
   "marshmallow": [
     "setuptools"
+    "flit-core"
   ],
   "marshmallow-dataclass": [
     "setuptools"
@@ -20866,6 +20867,7 @@
   ],
   "twisted": [
     "setuptools"
+    "hatchling"
   ],
   "twitch-python": [
     "setuptools"


### PR DESCRIPTION
I've experienced problems with building https://github.com/sp1thas/criticker-dataset without this