### PR TITLE
nvidia: use different method for making libraries work

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1792,39 +1792,27 @@ lib.composeManyExtensions [
               ];
             }) else prev.notebook;
 
-      nvidia-cudnn-cu11 = super.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
+      nvidia-cudnn-cu11 = prev.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
         propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu11
+          final.nvidia-cublas-cu11
         ];
       });
 
-      nvidia-cudnn-cu12 = super.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
+      nvidia-cudnn-cu12 = prev.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
         propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu12
+          final.nvidia-cublas-cu12
         ];
       });
 
-      nvidia-cusolver-cu11 = super.nvidia-cusolver-cu11.overridePythonAttrs (attrs: {
+      nvidia-cusolver-cu11 = prev.nvidia-cusolver-cu11.overridePythonAttrs (attrs: {
         propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu11
+          final.nvidia-cublas-cu11
         ];
       });
 
-      nvidia-cusolver-cu12 = super.nvidia-cusolver-cu11.overridePythonAttrs (attrs: {
+      nvidia-cusolver-cu12 = prev.nvidia-cusolver-cu11.overridePythonAttrs (attrs: {
         propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu12
-        ];
-      });
-
-      nvidia-cudnn-cu11 = super.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
-        propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu11
-        ];
-      });
-
-      nvidia-cudnn-cu12 = super.nvidia-cudnn-cu11.overridePythonAttrs (attrs: {
-        propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          self.nvidia-cublas-cu12
+          final.nvidia-cublas-cu12
         ];
       });
 
@@ -4001,7 +3989,7 @@ lib.composeManyExtensions [
     "nvidia-nvtx-cu11"
     "nvidia-nvtx-cu12"
   ]
-    (name: super.${name}.overridePythonAttrs (_old: {
+    (name: super.${name}.overridePythonAttrs (_: {
       # 1. Remove __init__.py because all the cuda packages include it
       # 2. Symlink the cuda libraries to the lib directory so autopatchelf can find them
       postFixup = ''

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2673,7 +2673,7 @@ lib.composeManyExtensions [
               dontWrapQtApps = true;
               dontConfigure = true;
               enableParallelBuilding = true;
-              # HACK: paralellize compilation of make calls within pyqt's setup.py
+              # HACK: parallelize compilation of make calls within pyqt's setup.py
               # pkgs/stdenv/generic/setup.sh doesn't set this for us because
               # make gets called by python code and not its build phase
               # format=pyproject means the pip-build-hook hook gets used to build this project

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3962,22 +3962,23 @@ lib.composeManyExtensions [
   # The following are dependencies of torch >= 2.0.0.
   # torch doesn't officially support system CUDA, unless you build it yourself.
   (self: super: lib.genAttrs
-    (lib.mapConcat
-      (pkg: [ "nvidia-${pkg}-cu11" "nvidia-${pkg}-cu12" ]) [
-      "cublas"
-      "cuda-cupti"
-      "cuda-curand"
-      "cuda-nvrtc"
-      "cuda-runtime"
-      "cudnn"
-      "cufft"
-      "curand"
-      "cusolver"
-      "cusparse"
-      "nccl"
-      "nvjitlink"
-      "nvtx"
-    ])
+    (lib.concatMap
+      (pkg: [ "nvidia-${pkg}-cu11" "nvidia-${pkg}-cu12" ])
+      [
+        "cublas"
+        "cuda-cupti"
+        "cuda-curand"
+        "cuda-nvrtc"
+        "cuda-runtime"
+        "cudnn"
+        "cufft"
+        "curand"
+        "cusolver"
+        "cusparse"
+        "nccl"
+        "nvjitlink"
+        "nvtx"
+      ])
     (name: super.${name}.overridePythonAttrs (_: {
       # 1. Remove __init__.py because all the cuda packages include it
       # 2. Symlink the cuda libraries to the lib directory so autopatchelf can find them

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3961,34 +3961,23 @@ lib.composeManyExtensions [
   )
   # The following are dependencies of torch >= 2.0.0.
   # torch doesn't officially support system CUDA, unless you build it yourself.
-  (self: super: lib.genAttrs [
-    "nvidia-cublas-cu11"
-    "nvidia-cublas-cu12"
-    "nvidia-cuda-cupti-cu11"
-    "nvidia-cuda-cupti-cu12"
-    "nvidia-cuda-curand-cu11"
-    "nvidia-cuda-curand-cu12"
-    "nvidia-cuda-nvrtc-cu11"
-    "nvidia-cuda-nvrtc-cu12"
-    "nvidia-cuda-runtime-cu11"
-    "nvidia-cuda-runtime-cu12"
-    "nvidia-cudnn-cu11"
-    "nvidia-cudnn-cu12"
-    "nvidia-cufft-cu11"
-    "nvidia-cufft-cu12"
-    "nvidia-curand-cu11"
-    "nvidia-curand-cu12"
-    "nvidia-cusolver-cu11"
-    "nvidia-cusolver-cu12"
-    "nvidia-cusparse-cu11"
-    "nvidia-cusparse-cu12"
-    "nvidia-nccl-cu11"
-    "nvidia-nccl-cu12"
-    "nvidia-nvjitlink-cu11"
-    "nvidia-nvjitlink-cu12"
-    "nvidia-nvtx-cu11"
-    "nvidia-nvtx-cu12"
-  ]
+  (self: super: lib.genAttrs
+    (lib.mapConcat
+      (pkg: [ "nvidia-${pkg}-cu11" "nvidia-${pkg}-cu12" ]) [
+      "cublas"
+      "cuda-cupti"
+      "cuda-curand"
+      "cuda-nvrtc"
+      "cuda-runtime"
+      "cudnn"
+      "cufft"
+      "curand"
+      "cusolver"
+      "cusparse"
+      "nccl"
+      "nvjitlink"
+      "nvtx"
+    ])
     (name: super.${name}.overridePythonAttrs (_: {
       # 1. Remove __init__.py because all the cuda packages include it
       # 2. Symlink the cuda libraries to the lib directory so autopatchelf can find them

--- a/tests/ml-stack/default.nix
+++ b/tests/ml-stack/default.nix
@@ -1,4 +1,4 @@
-{ poetry2nix, python310, runCommand }:
+{ poetry2nix, python310, runCommand, writeText }:
 let
   env = poetry2nix.mkPoetryEnv {
     python = python310;
@@ -6,10 +6,29 @@ let
     poetrylock = ./poetry.lock;
     preferWheels = true;
   };
+
+  testScript = writeText "test-ml-stack.py" ''
+    import torch
+    import torchvision
+
+    print(torch.__version__)
+    print(torchvision.__version__)
+
+    has_cuda = torch.cuda.is_available()
+
+    print("has_cuda = {}".format(has_cuda))
+
+    x = torch.randn(3, 3);
+
+    if has_cuda:
+        x = x.cuda()
+
+    print(x**2)
+  '';
 in
 # Note: torch.cuda() will print False, even if you have a GPU, when this runs *during test.*
-  # But if you run the script below in your shell (rather than during build), it will print True.
-  # Presumably this is due to sandboxing.
+# But if you run the script below in your shell (rather than during build), it will print True.
+# Presumably this is due to sandboxing.
 runCommand "ml-stack-test" { } ''
-  ${env}/bin/python -c 'import torch; import torchvision; print(torch.__version__); print(torchvision.__version__); print(torch.cuda.is_available()); x = torch.randn(3,3); x = x.cuda() if torch.cuda.is_available() else x; print(x**2)' > $out
+  ${env}/bin/python "${testScript}" > $out
 ''


### PR DESCRIPTION
This symlinks all the .so libraries to $out/lib/ so the autopatchelf hook can find them, instead of relying on torch's inbuilt magic to find the libraries.

I've also formatted it as a separate overlay that generates the override for all the nvidia packages.
