### PR TITLE
feat: Split flake template devShell: app and poetry

### DIFF
--- a/templates/app/flake.nix
+++ b/templates/app/flake.nix
@@ -23,8 +23,21 @@
           default = self.packages.${system}.myapp;
         };
 
+        # Shell for app dependencies.
+        #
+        #     nix develop
+        #
+        # Use this shell for developing your app.
         devShells.default = pkgs.mkShell {
           inputsFrom = [ self.packages.${system}.myapp ];
+        };
+
+        # Shell for poetry.
+        #
+        #     nix develop .#poetry
+        #
+        # Use this shell for changes to pyproject.toml and poetry.lock.
+        devShells.poetry = pkgs.mkShell {
           packages = [ pkgs.poetry ];
         };
       });


### PR DESCRIPTION
The nix template generates two devShells instead of one.

- The first devShell provides project dependencies, but not poetry.
- The second devShell provides only poetry.

In all of my **poetry2nix** projects this is the pattern that I use. I think this should be the default template `flake.nix`.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
