### PR TITLE
Refer to right pkg-config thing

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -972,7 +972,7 @@ lib.composeManyExtensions [
               nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkg-config ];
               buildInputs =
                 (old.buildInputs or [ ])
-                ++ [ pkgs.hdf5 self.pkg-config ]
+                ++ [ pkgs.hdf5 pkgs.pkg-config ]
                 ++ lib.optional mpiSupport mpi
               ;
               propagatedBuildInputs =


### PR DESCRIPTION
In #1447 some references of `pkgs.pkgconfig` were
change to `pkgs.pkg-config` which was correct, as
the `pkgs.pkgconfig` is a deprecated alias for the latter. However that change _also_ changed
`self.pkgconfig` to `self.pkg-config`: the `self`
here is _not_ the same as `pkgs`. The `self`
refers to Python package set so it formerly
referred to the `pkgconfig` Python package.
There's no `pkg-config` Python package so this
code just fails to evaluate, resulting in #1564.

In first place, it looks like using
`self.pkgconfig` was probably wrong and we wanted
the `pkgs.pkg-config` so I simply make that change instead.

Fixes #1564.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
