### PR TITLE
Remove 'subdirectory' from git dependency in hook

### DIFF
--- a/hooks/default.nix
+++ b/hooks/default.nix
@@ -46,7 +46,7 @@ in
   };
 
   removeGitDependenciesHook = makeRemoveSpecialDependenciesHook {
-    fields = [ "git" "branch" "rev" "tag" ];
+    fields = [ "git" "branch" "rev" "tag" "subdirectory" ];
     kind = "git";
   };
 


### PR DESCRIPTION
Otherwise I get the following error when using `mkPoetryApplication` with a git dependency with 'subdirectory':

```
> RuntimeError: The Poetry configuration is invalid:
>   - [dependencies.pycolmap] {'subdirectory': 'pycolmap', 'version': '*'} is not valid under any of the given schemas
```

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
