### PR TITLE
overrides: add gdspy, gdstk, update marshmallow, fix pillow 9.5.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -7620,6 +7620,9 @@
     "hatchling",
     "setuptools"
   ],
+  "gdspy": [
+    "setuptools"
+  ],
   "gdtoolkit": [
     "setuptools"
   ],

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2046,6 +2046,14 @@ lib.composeManyExtensions [
             ++ lib.optionals (lib.versionAtLeast old.version "7.1.0") [ xorg.libxcb ]
             ++ lib.optionals self.isPyPy [ tk xorg.libX11 ];
           preConfigure = lib.optional (old.format != "wheel") preConfigure;
+
+          # https://github.com/nix-community/poetry2nix/issues/1139
+          patches = (old.patches or [ ]) ++ pkgs.lib.optionals (old.version == "9.5.0") [
+            (pkgs.fetchpatch {
+              url = "https://github.com/python-pillow/Pillow/commit/0ec0a89ead648793812e11739e2a5d70738c6be5.diff";
+              sha256 = "sha256-rZfk+OXZU6xBpoumIW30E80gRsox/Goa3hMDxBUkTY0=";
+            })
+          ];
         }
       );
 

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -886,6 +886,23 @@ lib.composeManyExtensions [
         }
       );
 
+      gdstk = super.gdstk.overridePythonAttrs (old: {
+        buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools pkgs.zlib pkgs.qhull ];
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.cmake ];
+        dontUseCmakeConfigure = true;
+        # gdstk ships with its own FindQhull.cmake, but that isn't
+        # included in the python release -- fix
+        postPatch = ''
+          if [ ! -e cmake_modules/FindQhull.cmake ]; then
+            mkdir -p cmake_modules
+            cp ${pkgs.fetchurl {
+              url = "https://github.com/heitzmann/gdstk/raw/57c9ecec1f7bc2345182bcf383602a792026a28b/cmake_modules/FindQhull.cmake";
+              hash = "sha256-lJNWAfSItbg7jsHfe7gZryqJruHjjMM0GXudXa/SJu4=";
+            }} cmake_modules/FindQhull.cmake
+          fi
+        '';
+      });
+
       gnureadline = super.gnureadline.overridePythonAttrs (
         old: {
           buildInputs = (old.buildInputs or [ ]) ++ [ pkgs.ncurses ];

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2048,7 +2048,7 @@ lib.composeManyExtensions [
           preConfigure = lib.optional (old.format != "wheel") preConfigure;
 
           # https://github.com/nix-community/poetry2nix/issues/1139
-          patches = (old.patches or [ ]) ++ pkgs.lib.optionals (old.version == "9.5.0") [
+          patches = (old.patches or [ ]) ++ pkgs.lib.optionals (!(old.src.isWheel or false) && old.version == "9.5.0") [
             (pkgs.fetchpatch {
               url = "https://github.com/python-pillow/Pillow/commit/0ec0a89ead648793812e11739e2a5d70738c6be5.diff";
               sha256 = "sha256-rZfk+OXZU6xBpoumIW30E80gRsox/Goa3hMDxBUkTY0=";


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

The marshmallow one, it now has both `flit-core` and `setuptools`, I saw some other code above having both, thought that's probably simpler (might result in an extra unnecessary download/build, but probably not a big problem), than selecting based on version.

The pillow fix should help https://github.com/nix-community/poetry2nix/issues/1139

### Notes
From the README.md

> * This project uses [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) for formatting the Nix code. You can use nix-shell --run "nixpkgs-fmt ." to format everything.

Seems like there are a couple of unformatted things, when I ran this -- I only used the formatting on the newly added lines, to avoid noise.