### PR TITLE
fix(pendulum): fix sphinx-7.2.6 not supported for interpreter python3.8

### DIFF
--- a/tests/pendulum/default.nix
+++ b/tests/pendulum/default.nix
@@ -1,7 +1,7 @@
-{ lib, poetry2nix, python38 }:
+{ lib, poetry2nix, python3 }:
 poetry2nix.mkPoetryApplication {
   pyproject = ./pyproject.toml;
   poetrylock = ./poetry.lock;
   src = lib.cleanSource ./.;
-  python = python38;
+  python = python3;
 }


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
