### PR TITLE
docs: fix typo: "wheels our sdists" → "wheels or sdists"

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ in pkgs.poetry2nix.mkPoetryApplication {
 
 ## FAQ
 
-**Q.** Does poetry2nix install wheels our sdists?
+**Q.** Does poetry2nix install wheels or sdists?
 
 **A.** By default, poetry2nix installs from source. If you want to give precedence to wheels, look at the `preferWheel` and `preferWheels` attributes.
 


### PR DESCRIPTION
The FAQ question is about the choice between the two alternatives (a) "wheels" vs. (b) "sdists", not about whose sdists they are.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
