### PR TITLE
vendor: pass NETRC via impureEnvVars if inPureEval

### DIFF
--- a/vendor/pyproject.nix/fetchers/default.nix
+++ b/vendor/pyproject.nix/fetchers/default.nix
@@ -116,15 +116,14 @@ lib.mapAttrs (_: func: lib.makeOverridable func) {
         else "";
     in
     runCommand file
-      {
+      ({
         nativeBuildInputs = [ python3 ];
-        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ (lib.optional lib.inPureEvalMode "NETRC");
         outputHashMode = "flat";
         outputHashAlgo = "sha256";
         outputHash = hash;
-        NETRC = netrc_file;
         passthru.isWheel = lib.strings.hasSuffix "whl" file;
-      } ''
+      } // lib.optionalAttrs (!lib.inPureEvalMode) { NETRC = netrc_file; }) ''
       python ${./fetch-from-legacy.py} ${url} ${pname} ${file}
       mv ${file} $out
     '';


### PR DESCRIPTION
When using flakes, pure evaluation mode prevents arguments supplied by `-I` such as `-I NETRC=...` from being passed, instead returning an empty list, which makes using the `NETRC` option for fetching proprietary code impossible when using Flakes. This PR simply adds NETRC to the list of `impureEnvVars` to be passed if set in the nix-daemon service via `systemd.services.nix-daemon.serviceConfig.Environment="netrc=/path/to/netrc"` if you are using pure evaluation mode. This PR makes `NETRC` useful for both flakes and non-flakes usage.

```
user: matthew ~
❯ nix repl --pure-eval
Nix 2.21.2
Type :? for help.
nix-repl> builtins.nixPath
[ ]

user: matthew ~
❯ nix repl
Nix 2.21.2
Type :? for help.
nix-repl> builtins.nixPath
[ { ... } ]
```

