### PR TITLE
Mark altgraph, macholib, and pyinstaller-hooks-contrib as needing setuptools

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11147,6 +11147,9 @@
   "macaroonbakery": [
     "setuptools"
   ],
+  "macholib": [
+    "setuptools"
+  ],
   "maestral": [
     "pbr",
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17255,6 +17255,9 @@
   "pyinputevent": [
     "setuptools"
   ],
+  "pyinstaller-hooks-contrib": [
+    "setuptools"
+  ],
   "pyinsteon": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -817,6 +817,9 @@
     "hatchling",
     "setuptools"
   ],
+  "altgraph": [
+    "setuptools"
+  ],
   "amaranth": [
     "setuptools",
     "setuptools-scm"


### PR DESCRIPTION
Redux of #1543.