### PR TITLE
Patch llama-index to remove conflicting file

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1392,6 +1392,13 @@ lib.composeManyExtensions [
         }
       );
 
+      llama-index = prev.llama-index.overridePythonAttrs (_old: {
+        postInstall = ''
+          # Conflicts with same file from `llama-index-cli`
+          rm -f $out/bin/llamaindex-cli
+        '';
+      });
+
       llvmlite = prev.llvmlite.overridePythonAttrs (
         old:
         let


### PR DESCRIPTION
Conflicts with `llamaindex-cli` file from [llama-index-cli](https://pypi.org/project/llama-index-cli/) package

Without this change, I get this error:

```nix
> error: collision between `/nix/store/561w0gwm3g4wgyfq3p1z4lfzzb3wiwcy-python3.11-llama-index-cli-0.1.12/bin/.llamaindex-cli-wrapped' and `/nix/store/qp79rzbl0r73bwkn5kn6nr0xmis2zn9i-python3.11-llama-index-0.10.30/bin/.llamaindex-cli-wrapped'
```

I removed the conflict from `llama-index`, since it seems more appropriate for `llama-index-cli` to provide the `llamaindex-cli` command.

Not sure that this is the right approach and can update it it there's a better way, but it worked for my use case.