### PR TITLE
Add and fix several django-related build system overrides

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5513,10 +5513,10 @@
   "django-permissionedforms": [
     "setuptools"
   ],
-  "django-pglocks": [
+  "django-pg-zero-downtime-migrations": [
     "setuptools"
   ],
-  "django-pg-zero-downtime-migrations": [
+  "django-pglocks": [
     "setuptools"
   ],
   "django-phonenumber-field": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -21,6 +21,9 @@
   "accelerate": [
     "setuptools"
   ],
+  "access-points": [
+    "setuptools"
+  ],
   "accuweather": [
     "setuptools"
   ],
@@ -4088,6 +4091,9 @@
   "contexttimer": [
     "setuptools"
   ],
+  "contextvars": [
+    "setuptools"
+  ],
   "contourpy": [
     "pybind11",
     {
@@ -4739,6 +4745,9 @@
     "cython",
     "setuptools"
   ],
+  "ddtrace-graphql": [
+    "setuptools"
+  ],
   "deal": [
     "flit-core",
     "setuptools"
@@ -5198,6 +5207,12 @@
   "django-5": [
     "setuptools"
   ],
+  "django-add-default-value": [
+    "setuptools"
+  ],
+  "django-admin-multiple-choice-list-filter": [
+    "setuptools"
+  ],
   "django-admin-sortable2": [
     "setuptools"
   ],
@@ -5206,6 +5221,9 @@
   ],
   "django-allauth-2fa": [
     "hatchling"
+  ],
+  "django-annoying": [
+    "setuptools"
   ],
   "django-anymail": [
     "hatchling",
@@ -5240,6 +5258,9 @@
   ],
   "django-bootstrap5": [
     "hatchling",
+    "setuptools"
+  ],
+  "django-braces": [
     "setuptools"
   ],
   "django-cache-memoize": [
@@ -5279,6 +5300,9 @@
     "setuptools"
   ],
   "django-compressor": [
+    "setuptools"
+  ],
+  "django-concurrency": [
     "setuptools"
   ],
   "django-configurations": [
@@ -5322,6 +5346,9 @@
   "django-currentuser": [
     "hatchling"
   ],
+  "django-debug-panel": [
+    "setuptools"
+  ],
   "django-debug-toolbar": [
     {
       "buildSystem": "setuptools",
@@ -5331,6 +5358,12 @@
       "buildSystem": "hatchling",
       "from": "3.8.0"
     }
+  ],
+  "django-decorator-include": [
+    "setuptools"
+  ],
+  "django-deprecate-fields": [
+    "setuptools"
   ],
   "django-discover-runner": [
     "setuptools"
@@ -5342,6 +5375,9 @@
     "poetry-core",
     "setuptools"
   ],
+  "django-enumfields": [
+    "setuptools"
+  ],
   "django-environ": [
     "setuptools"
   ],
@@ -5350,6 +5386,9 @@
   ],
   "django-filter": [
     "flit-core",
+    "setuptools"
+  ],
+  "django-fixture-magic": [
     "setuptools"
   ],
   "django-floppyforms": [
@@ -5401,6 +5440,9 @@
   ],
   "django-js-asset": [
     "hatchling",
+    "setuptools"
+  ],
+  "django-json-widget": [
     "setuptools"
   ],
   "django-libsass": [
@@ -5474,6 +5516,9 @@
   "django-pglocks": [
     "setuptools"
   ],
+  "django-pg-zero-downtime-migrations": [
+    "setuptools"
+  ],
   "django-phonenumber-field": [
     "setuptools",
     "setuptools-scm"
@@ -5500,10 +5545,16 @@
   "django-qr-code": [
     "setuptools"
   ],
+  "django-quicky": [
+    "setuptools"
+  ],
   "django-ranged-response": [
     "setuptools"
   ],
   "django-raster": [
+    "setuptools"
+  ],
+  "django-ratelimit": [
     "setuptools"
   ],
   "django-redis": [
@@ -5533,14 +5584,23 @@
   "django-rq": [
     "setuptools"
   ],
+  "django-rq-scheduler": [
+    "setuptools"
+  ],
   "django-scim2": [
     "poetry-core"
   ],
   "django-scopes": [
     "setuptools"
   ],
+  "django-ses": [
+    "setuptools"
+  ],
   "django-sesame": [
     "poetry-core",
+    "setuptools"
+  ],
+  "django-session-security": [
     "setuptools"
   ],
   "django-silk": [
@@ -5595,6 +5655,9 @@
   ],
   "django-types": [
     "poetry-core"
+  ],
+  "django-user-agents": [
+    "setuptools"
   ],
   "django-versatileimagefield": [
     "setuptools"
@@ -8326,6 +8389,9 @@
   "graphene-django": [
     "setuptools"
   ],
+  "graphene-django-optimizer": [
+    "setuptools"
+  ],
   "graphite-web": [
     "setuptools"
   ],
@@ -8345,6 +8411,9 @@
     "setuptools"
   ],
   "graphql-subscription-manager": [
+    "setuptools"
+  ],
+  "graphql-ws": [
     "setuptools"
   ],
   "graphqlclient": [
@@ -11504,6 +11573,9 @@
   "mdp": [
     "setuptools"
   ],
+  "mdstat": [
+    "setuptools"
+  ],
   "mdtraj": [
     "cython_0",
     "setuptools"
@@ -11570,6 +11642,9 @@
     "setuptools"
   ],
   "memory-profiler": [
+    "setuptools"
+  ],
+  "meraki": [
     "setuptools"
   ],
   "mercantile": [
@@ -15793,6 +15868,9 @@
   "pprintpp": [
     "setuptools"
   ],
+  "pprofile": [
+    "setuptools"
+  ],
   "pproxy": [
     "setuptools"
   ],
@@ -19098,6 +19176,9 @@
   "pytest-resource-path": [
     "setuptools"
   ],
+  "pytest-retry": [
+    "setuptools"
+  ],
   "pytest-reverse": [
     "setuptools"
   ],
@@ -21153,6 +21234,9 @@
   ],
   "rq": [
     "hatchling",
+    "setuptools"
+  ],
+  "rq-scheduler": [
     "setuptools"
   ],
   "rsa": [

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2803,8 +2803,11 @@ lib.composeManyExtensions [
       pytest-django = prev.pytest-django.overridePythonAttrs (
         _old: {
           postPatch = ''
-            substituteInPlace setup.py --replace "'pytest>=3.6'," ""
-            substituteInPlace setup.py --replace "'pytest>=3.6'" ""
+            # sometimes setup.py doesn't exist
+            if [ -f setup.py ]; then
+              substituteInPlace setup.py --replace "'pytest>=3.6'," ""
+              substituteInPlace setup.py --replace "'pytest>=3.6'" ""
+            fi
           '';
         }
       );

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -640,7 +640,10 @@ lib.composeManyExtensions [
 
       daphne = prev.daphne.overridePythonAttrs (_old: {
         postPatch = ''
-          substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"],' ""
+          # sometimes setup.py doesn't exist
+          if [ -f setup.py ]; then
+            substituteInPlace setup.py --replace 'setup_requires=["pytest-runner"],' ""
+          fi
         '';
       });
 


### PR DESCRIPTION
These are all the overrides needed to get a large, old Django app to build by default. I tested building a poetryEnv for that app locally with this branch and it's working as expected!

I'm not entirely sure why `setup.py` is sometimes missing for `pytest-django` and `daphne`, but I'm guessing it has something to do with `preferWheels` since we have that enabled. It looked like other overrides already have similar file checks.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
