### PR TITLE
fix matplotlib override

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1607,13 +1607,11 @@ lib.composeManyExtensions [
             in
             lib.optionalString enableTk ''
               sed -i '/final.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py
-            '' + lib.optionalString (stdenv.isLinux && interactive) ''
+            '' + lib.optionalString (stdenv.isLinux && interactive && !(old.src.isWheel or false)) ''
               # fix paths to libraries in dlopen calls (headless detection)
-              if test -d src; then
-                substituteInPlace src/_c_internal_utils.c \
-                  --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
-                  --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
-              fi
+              substituteInPlace src/_c_internal_utils.c \
+                --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
+                --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
             ''
             # avoid matplotlib trying to download dependencies
             + lib.optionalString mpl39

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1609,10 +1609,13 @@ lib.composeManyExtensions [
               sed -i '/final.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py
             '' + lib.optionalString (stdenv.isLinux && interactive) ''
               # fix paths to libraries in dlopen calls (headless detection)
-              substituteInPlace src/_c_internal_utils.c \
-                --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
-                --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
+              if test -d src; then
+                substituteInPlace src/_c_internal_utils.c \
+                  --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
+                  --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
+              fi
             ''
+            # avoid matplotlib trying to download dependencies
             + lib.optionalString mpl39
               ''
                 patchShebangs .

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1570,7 +1570,7 @@ lib.composeManyExtensions [
             pkgs.freetype
             qhull
           ]
-            ++ lib.optionals enableGtk3 [ pkgs.cairo final.pycairo pkgs.gtk3 pkgs.gobject-introspection final.pygobject3 ]
+            ++ lib.optionals enableGtk3 [ pkgs.cairo pkgs.librsvg final.pycairo pkgs.gtk3 pkgs.gobject-introspection final.pygobject3 ]
             ++ lib.optionals enableTk [ pkgs.tcl pkgs.tk final.tkinter pkgs.libX11 ]
             ++ lib.optionals enableQt [ final.pyqt5 ]
           ;

--- a/tests/matplotlib-3-6/default.nix
+++ b/tests/matplotlib-3-6/default.nix
@@ -1,10 +1,18 @@
 { poetry2nix, runCommand }:
 let
-  env = poetry2nix.mkPoetryEnv {
+  mkEnv = preferWheel: poetry2nix.mkPoetryEnv {
     projectDir = ./.;
+    overrides = poetry2nix.overrides.withDefaults (
+      _: prev: {
+        matplotlib = prev.matplotlib.override {
+          inherit preferWheel;
+        };
+      }
+    );
   };
 in
 runCommand "matplotlib-3-6-test" { } ''
-  ${env}/bin/python -c 'import matplotlib'
+  ${mkEnv true}/bin/python -c 'import matplotlib'
+  ${mkEnv false}/bin/python -c 'import matplotlib'
   touch $out
 ''

--- a/tests/matplotlib-3-7/default.nix
+++ b/tests/matplotlib-3-7/default.nix
@@ -1,10 +1,18 @@
 { poetry2nix, runCommand }:
 let
-  env = poetry2nix.mkPoetryEnv {
+  mkEnv = preferWheel: poetry2nix.mkPoetryEnv {
     projectDir = ./.;
+    overrides = poetry2nix.overrides.withDefaults (
+      _: prev: {
+        matplotlib = prev.matplotlib.override {
+          inherit preferWheel;
+        };
+      }
+    );
   };
 in
 runCommand "matplotlib-3-7-test" { } ''
-  ${env}/bin/python -c 'import matplotlib'
+  ${mkEnv true}/bin/python -c 'import matplotlib'
+  ${mkEnv false}/bin/python -c 'import matplotlib'
   touch $out
 ''

--- a/tests/matplotlib-3-9/default.nix
+++ b/tests/matplotlib-3-9/default.nix
@@ -1,10 +1,18 @@
 { poetry2nix, runCommand }:
 let
-  env = poetry2nix.mkPoetryEnv {
+  mkEnv = preferWheel: poetry2nix.mkPoetryEnv {
     projectDir = ./.;
+    overrides = poetry2nix.overrides.withDefaults (
+      _: prev: {
+        matplotlib = prev.matplotlib.override {
+          inherit preferWheel;
+        };
+      }
+    );
   };
 in
 runCommand "matplotlib-3-9-test" { } ''
-  ${env}/bin/python -c 'import matplotlib'
+  ${mkEnv true}/bin/python -c 'import matplotlib'
+  ${mkEnv false}/bin/python -c 'import matplotlib'
   touch $out
 ''


### PR DESCRIPTION
This little patch allows skipping the patching of a source file in matplotlib if a wheel is used, and it is thus not available. For me this "works" but maybe there is some objection to doing it this way.

Can `preferWheels = true` be detected/accessed inside the override?

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
