### PR TITLE
overrides: add flit-core dependency to itsdangerous

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1221,6 +1221,12 @@ lib.composeManyExtensions [
         }
       );
 
+      itsdangerous = prev.itsdangerous.overridePythonAttrs (
+        old: {
+          propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ final.flit-core ];
+        }
+      );
+
       jaraco-functools = prev.jaraco-functools.overridePythonAttrs (
         old: {
           # required for the extra "toml" dependency in setuptools_scm[toml]


### PR DESCRIPTION
I tried to build the example in the blog post tutorial. It failed, because flask uses itsdangerous, which uses flit.

With the added override, it works fine.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
