### PR TITLE
Remove implicit tensorflow-macos dependency on tensorflow

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -144,6 +144,11 @@ lib.composeManyExtensions [
         doCheck = false;
         cmakeFlags = old.cmakeFlags or [ ] ++ [ "-DBUILD_PYTHON_BINDINGS=OFF" ];
       });
+      tensorflowAttrs = {
+        postInstall = ''
+          rm $out/bin/tensorboard
+        '';
+      };
     in
 
     {
@@ -3499,25 +3504,16 @@ lib.composeManyExtensions [
       );
 
       tensorflow = prev.tensorflow.overridePythonAttrs (
-        # keep in sync with tensorflow-macos below
-        _old: {
-          postInstall = ''
-            rm $out/bin/tensorboard
-          '';
-        }
+        _old: tensorflowAttrs
       );
 
       tensorflow-macos = prev.tensorflow-macos.overridePythonAttrs (
         # Alternative tensorflow community package for MacOS only.
-        # We don't want to create an implicit dependency on the normal tensorflow package,
-        # because some versions don't exist for MacOS, especially ARM Macs.
-        # 
-        # So keep pre and post-processing (if needed) in sync with tensorflow above manually here.
-        _old: {
-          postInstall = ''
-            rm $out/bin/tensorboard
-          '';
-        }
+        #
+        # We don't want to create an implicit dependency on the normal
+        # tensorflow package, because some versions don't exist for MacOS,
+        # especially ARM Macs.
+        _old: tensorflowAttrs
       );
 
       tensorpack = prev.tensorpack.overridePythonAttrs (

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3499,6 +3499,7 @@ lib.composeManyExtensions [
       );
 
       tensorflow = prev.tensorflow.overridePythonAttrs (
+        # keep in sync with tensorflow-macos below
         _old: {
           postInstall = ''
             rm $out/bin/tensorboard
@@ -3507,8 +3508,15 @@ lib.composeManyExtensions [
       );
 
       tensorflow-macos = prev.tensorflow-macos.overridePythonAttrs (
+        # Alternative tensorflow community package for MacOS only.
+        # We don't want to create an implicit dependency on the normal tensorflow package,
+        # because some versions don't exist for MacOS, especially ARM Macs.
+        # 
+        # So keep pre and post-processing (if needed) in sync with tensorflow above manually here.
         _old: {
-          inherit (final.tensorflow) postInstall;
+          postInstall = ''
+            rm $out/bin/tensorboard
+          '';
         }
       );
 


### PR DESCRIPTION
Poetry2nix tensorflow-macos overlay creates an implicit dependency on tensorflow, so that you always end up trying to install the normal tensorflow, which sometimes doesn't work: Some older tensorflow versions have broken ARM packages or don't exist at all; sometimes you just want tensorflow-macos.

So remove that dependency.

Contributes to https://github.com/nix-community/poetry2nix/issues/1609.

Feel free to do changes, request changes or reject this PR as you wish. 

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
