### PR TITLE
overrides: numpy 2

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14162,6 +14162,10 @@
     {
       "buildSystem": "cython",
       "from": "1.26.0"
+    },
+    {
+      "buildSystem": "meson-python",
+      "from": "2.0.0"
     }
   ],
   "numpy-financial": [

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1783,7 +1783,10 @@ lib.composeManyExtensions [
           # fails to build with format=pyproject and setuptools >= 65
           format =
             if ((old.format or null) == "poetry2nix") then
-              "setuptools"
+              (if lib.versionAtLeast prev.numpy.version "2.0.0" then
+                 "pyproject"
+               else "setuptools"
+            )
             else
               old.format or null;
           nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ gfortran ];


### PR DESCRIPTION
Numpy switched build systems.

Fixes #1708.

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
