### PR TITLE
fix(pyogrio): fix python 3.10 builds

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2462,7 +2462,9 @@ lib.composeManyExtensions [
       );
 
       pyogrio = prev.pyogrio.overridePythonAttrs (old: {
-        nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ final.versioneer gdal ];
+        nativeBuildInputs = old.nativeBuildInputs or [ ]
+          ++ [ final.versioneer gdal ]
+          ++ lib.optionals (final.pythonOlder "3.11") [ final.tomli ];
       });
 
       pyopencl = prev.pyopencl.overridePythonAttrs (

--- a/tests/pyogrio/default.nix
+++ b/tests/pyogrio/default.nix
@@ -1,7 +1,7 @@
-{ poetry2nix, python3, runCommand }:
+{ poetry2nix, python310, runCommand }:
 let
   mkEnv = preferWheel: poetry2nix.mkPoetryEnv {
-    python = python3;
+    python = python310;
     pyproject = ./pyproject.toml;
     poetrylock = ./poetry.lock;
     overrides = poetry2nix.overrides.withDefaults (


### PR DESCRIPTION
Fixes python 3.10 build for pyogrio, which requires tomli in that case.