### PR TITLE
Add iterpy, monoyed and launchdarkly to overrides build systems

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9777,6 +9777,9 @@
   "iterative-telemetry": [
     "setuptools-scm"
   ],
+  "iterpy": [
+    "setuptools"
+  ],
   "itsdangerous": [
     "flit-core",
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16454,6 +16454,9 @@
   "py-lru-cache": [
     "setuptools"
   ],
+  "py-moneyed": [
+    "setuptools"
+  ],
   "py-multiaddr": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10646,6 +10646,9 @@
   "latexify-py": [
     "hatchling"
   ],
+  "launchdarkly-eventsource": [
+    "poetry-core"
+  ],
   "launchpadlib": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10649,6 +10649,9 @@
   "launchdarkly-eventsource": [
     "poetry-core"
   ],
+  "launchdarkly-server-sdk": [
+    "poetry-core"
+  ],
   "launchpadlib": [
     "setuptools"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
