### PR TITLE
fix(overrides): sqlmodel: switch to pdm

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -23001,7 +23001,14 @@
     "setuptools"
   ],
   "sqlmodel": [
-    "pdm-backend"
+    {
+      "buildSystem": "poetry-core",
+      "until": "0.0.17"
+    },
+    {
+      "buildSystem": "pdm-backend",
+      "from": "0.0.17"
+    }
   ],
   "sqlobject": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -23001,7 +23001,7 @@
     "setuptools"
   ],
   "sqlmodel": [
-    "poetry-core"
+    "pdm-backend"
   ],
   "sqlobject": [
     "setuptools"


### PR DESCRIPTION
sqlmodel migrated from Poetry to PDM with:
https://github.com/tiangolo/sqlmodel/pull/912

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
