### PR TITLE
overrides: sse-starlette switch to pdm-backend

### DIFF
--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -160,7 +160,7 @@ poetry2nix.mkPoetryApplication {
       second-dependency = prev.second-dependency.overridePythonAttrs
       (
         old: {
-          buildInputs = (old.buildInputs or [ ]) ++ [ prev.pdm ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ prev.pdm-backend ];
         }
       );
     });

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -23075,7 +23075,14 @@
     "setuptools"
   ],
   "sse-starlette": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "1.8.1"
+    },
+    {
+      "buildSystem": "pdm-backend",
+      "from": "1.8.1"
+    }
   ],
   "sseclient": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -23405,8 +23405,8 @@
     "setuptools-scm"
   ],
   "svcs": [
-    "hatchling",
-    "hatch-fancy-pypi-readme"
+    "hatch-fancy-pypi-readme",
+    "hatchling"
   ],
   "svg-path": [
     "setuptools"


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
