### PR TITLE
Update README to use newer `python3` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Creates an attribute set of the shape `{ python, poetryPackages, pyProject, poet
 ```nix
 poetry2nix.mkPoetryPackages {
     projectDir = ./.;
-    python = python35;
+    python3 = python39;
 }
 ```
 
@@ -303,7 +303,7 @@ Creates a package containing the scripts from `tool.poetry.scripts` of the `pypr
 ```nix
 poetry2nix.mkPoetryScriptsPackage {
     projectDir = ./.;
-    python = python35;
+    python3 = python39;
 }
 ```
 
@@ -321,7 +321,7 @@ Creates a package containing editable sources. Changes in the specified paths wi
 ```nix
 poetry2nix.mkPoetryEditablePackage {
     projectDir = ./.;
-    python = python35;
+    python3 = python39;
     editablePackageSources = {
         my-app = ./src;
     };


### PR DESCRIPTION
It seems like this changed ages ago but the docs didn't. Perhaps there are other places that need changing too.

Also used a non-deprecated (3.9) example Python version to go to

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
