### PR TITLE
fix(lxml): Add missing zlib dependency

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1474,7 +1474,7 @@ lib.composeManyExtensions [
             old.nativeBuildInputs or [ ]
             ++ [ pkg-config libxml2.dev libxslt.dev ]
             ++ lib.optionals stdenv.isDarwin [ xcodebuild ];
-          buildInputs = old.buildInputs or [ ] ++ [ pkgs.libxml2 pkgs.libxslt ];
+          buildInputs = old.buildInputs or [ ] ++ [ pkgs.libxml2 pkgs.libxslt pkgs.zlib ];
         }
       );
 


### PR DESCRIPTION
Somewhere between nixpkgs 693bc46d169f5af9c992095736e82c3488bf7dbb and 52ec9ac3b12395ad677e8b62106f0b98c1f8569d, lxml stopped building because it could no longer use zlib as pulled in by one of its dependencies (perhaps Python itself?)

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
