### PR TITLE
overrides: update hypothesis-graphql

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9224,7 +9224,14 @@
     "setuptools"
   ],
   "hypothesis-graphql": [
-    "poetry"
+    {
+      "buildSystem": "poetry",
+      "until": "0.10.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "0.10.0"
+    }
   ],
   "hypothesis-jsonschema": [
     "setuptools"


### PR DESCRIPTION
The upstream project switched to hatchling in https://github.com/Stranger6667/hypothesis-graphql/commit/f4dd109b5b9af4ee648e881e7aa0d1e08b1f745c.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
