### PR TITLE
fix(jira): drop setuptools-scm-git-archive

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1253,7 +1253,6 @@ lib.composeManyExtensions [
             final.pytestrunner
             final.cryptography
             final.pyjwt
-            final.setuptools-scm-git-archive
           ];
         }
       );


### PR DESCRIPTION
This package is marked as broken and is unnecessary.

Per @RCoeurjoly in https://github.com/nix-community/poetry2nix/issues/1607#issuecomment-2067734269_

  Note that according to https://pypi.org/project/setuptools-scm-git-archive/

  This plugin is obsolete. ``setuptools_scm >= 7.0.0`` supports Git archives by itself.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [X] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [X] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
