### PR TITLE
overrides: Disable fortify during build of msgspec to avoid SIGABRT during JSON generation

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1647,6 +1647,11 @@ lib.composeManyExtensions [
         }
       );
 
+      msgspec = prev.msgspec.overridePythonAttrs (old: {
+        # crash during integer serialization - see https://github.com/jcrist/msgspec/issues/730
+        hardeningDisable = old.hardeningDisable or [] ++ [ "fortify" ];
+      });
+
       munch = prev.munch.overridePythonAttrs (
         old: {
           # Latest version of pypi imports pkg_resources at runtime, so setuptools is needed at runtime. :(


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [X] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [X] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
