### PR TITLE
Treat default dependencies as main group

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,8 +83,9 @@ let
       buildInputs = mkInput "buildInputs" (if includeBuildSystem then buildSystemPkgs else [ ]);
       propagatedBuildInputs = mkInput "propagatedBuildInputs" (
         let
-          availableGroups = {main.dependencies = allRawDeps;} // pyProject.tool.poetry.group or { };
-        in lib.flatten (map (g: getDeps availableGroups.${g}.dependencies or {}) groups)
+          availableGroups = { main.dependencies = allRawDeps; } // pyProject.tool.poetry.group or { };
+        in
+        lib.flatten (map (g: getDeps availableGroups.${g}.dependencies or { }) groups)
       );
       nativeBuildInputs = mkInput "nativeBuildInputs" [ ];
       checkInputs = mkInput "checkInputs" checkInputs';
@@ -331,10 +332,11 @@ lib.makeScope pkgs.newScope (self: {
 
       allEditablePackageSources = (getEditableDeps (pyProject.tool.poetry."dev-dependencies" or { }))
         // (
-          let 
-            deps = pyProject.tool.poetry."dependencies" or { };
-            availableGroups = {main.dependencies = deps;} // pyProject.tool.poetry.group or { };
-          in builtins.foldl' (acc: g: acc // getEditableDeps availableGroups.${g}.dependencies or {}) { } groups
+        let
+          deps = pyProject.tool.poetry."dependencies" or { };
+          availableGroups = { main.dependencies = deps; } // pyProject.tool.poetry.group or { };
+        in
+        builtins.foldl' (acc: g: acc // getEditableDeps availableGroups.${g}.dependencies or { }) { } groups
       )
         // editablePackageSources;
 

--- a/default.nix
+++ b/default.nix
@@ -84,7 +84,7 @@ let
       propagatedBuildInputs = mkInput "propagatedBuildInputs" (
         let
           availableGroups = {main.dependencies = allRawDeps;} // pyProject.tool.poetry.group or { };
-        in lib.flatten (map (g: getDeps availableGroups.${g}.dependencies) groups)
+        in lib.flatten (map (g: getDeps availableGroups.${g}.dependencies or {}) groups)
       );
       nativeBuildInputs = mkInput "nativeBuildInputs" [ ];
       checkInputs = mkInput "checkInputs" checkInputs';
@@ -334,7 +334,7 @@ lib.makeScope pkgs.newScope (self: {
           let 
             deps = pyProject.tool.poetry."dependencies" or { };
             availableGroups = {main.dependencies = deps;} // pyProject.tool.poetry.group or { };
-          in builtins.foldl' (acc: g: acc // getEditableDeps availableGroups.${g}.dependencies) { } groups
+          in builtins.foldl' (acc: g: acc // getEditableDeps availableGroups.${g}.dependencies or {}) { } groups
       )
         // editablePackageSources;
 


### PR DESCRIPTION
Poetry documentation on dependency groups [1] says:
  "The dependencies declared in tool.poetry.dependencies are part of an
implicit main group."

The current implementation does not account for that and in particular does not allow to skip installation of default dependencies like in one of
`poetry install --without main`
`poetry install --only-root`
`poetry install --only othergroup`.

This commit adds main as an implicit group and also adds it as a default value where applicable.

[1]
https://python-poetry.org/docs/managing-dependencies#dependency-groups

Closes #1578

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
