### PR TITLE
Add overrides for kubernetes-validate, os-client-config and sphinx-multiversion

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14966,11 +14966,11 @@
   "orvibo": [
     "setuptools"
   ],
-  "os-service-types": [
-    "pbr",
+  "os-client-config": [
     "setuptools"
   ],
-  "os-client-config": [
+  "os-service-types": [
+    "pbr",
     "setuptools"
   ],
   "osc": [

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -10664,6 +10664,9 @@
   "kubernetes-stubs": [
     "poetry"
   ],
+  "kubernetes-validate": [
+    "setuptools"
+  ],
   "l18n": [
     "setuptools"
   ],
@@ -14965,6 +14968,9 @@
   ],
   "os-service-types": [
     "pbr",
+    "setuptools"
+  ],
+  "os-client-config": [
     "setuptools"
   ],
   "osc": [
@@ -22921,6 +22927,9 @@
     "setuptools"
   ],
   "sphinx-multitoc-numbering": [
+    "setuptools"
+  ],
+  "sphinx-multiversion": [
     "setuptools"
   ],
   "sphinx-notfound-page": [


### PR DESCRIPTION
add overrides for kubernetes-validate, os-client-config and sphinx-multiversion

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
