### PR TITLE
overrides: fix patch for imagecodecs

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -1143,7 +1143,7 @@ lib.composeManyExtensions [
           patchPhase = ''
             substituteInPlace setup.py \
               --replace "/usr/include/openjpeg-2.3" \
-                        "${pkgs.openjpeg.dev}/include/${pkgs.openjpeg.dev.incDir}
+                        "${pkgs.openjpeg.dev}/include/${pkgs.openjpeg.dev.incDir}"
             substituteInPlace setup.py \
               --replace "/usr/include/jxrlib" \
                         "$out/include/libjxr"


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

---

This PR fixes the following error:

```
error: builder for '/nix/store/v1bz2vfmfapa4h986gz26sg214sw8559-python3.12-imagecodecs-2024.6.1.drv' failed with exit code 2;
       last 10 log lines:
       > Using pypaInstallPhase
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Running phase: unpackPhase
       > Executing wheelUnpackPhase
       > Finished executing wheelUnpackPhase
       > Running phase: patchPhase
       > /nix/store/hix7sl0wxajb5aq14afjdvzc3w0i8b14-stdenv-linux/setup: eval: line 1716: unexpected EOF while looking for matching `"
'
       For full logs, run 'nix log /nix/store/v1bz2vfmfapa4h986gz26sg214sw8559-python3.12-imagecodecs-2024.6.1.drv'.

```