### PR TITLE
fix(overrides): migrate pycairo to meson-python (and fix dependencies)

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16774,7 +16774,18 @@
     "setuptools"
   ],
   "pycairo": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "1.27.0"
+    },
+    {
+      "buildSystem": "meson-python",
+      "from": "1.27.0"
+    },
+    {
+      "buildSystem": "ninja",
+      "from": "1.27.0"
+    }
   ],
   "pycangjie": [
     "cython",

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11810,6 +11810,10 @@
   "meson": [
     "setuptools"
   ],
+  "meson-python": [
+    "meson",
+    "ninja"
+  ],
   "mesonpep517": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -18301,7 +18301,14 @@
     "flit-core"
   ],
   "pyproject-metadata": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "0.8.0"
+    },
+    {
+      "buildSystem": "flit-core",
+      "from": "0.8.0"
+    }
   ],
   "pyprosegur": [
     "setuptools"


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

Explanation:
- `pycairo` uses `meson-python` [as of 1.27.0](https://github.com/pygobject/pycairo/compare/v1.26.1...v1.27.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
- `meson-python` has [basically always](https://github.com/mesonbuild/meson-python/blob/0.1.0/pyproject.toml) required `meson` and `ninja`. It also depends on `pyproject-metadata` but that seems to work without overrides.
- `pyproject-metadata` uses `flit-core` [as of 0.8.0](https://github.com/pypa/pyproject-metadata/compare/0.7.1...0.8.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).