### PR TITLE
overrides: add objprint, pye3d and viztracer

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -17123,6 +17123,11 @@
     "flit-core",
     "setuptools"
   ],
+  "pye3d": [
+    "cmake",
+    "cython",
+    "setuptools"
+  ],
   "pyeapi": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -14274,6 +14274,9 @@
   "objgraph": [
     "setuptools"
   ],
+  "objprint": [
+    "setuptools"
+  ],
   "objsize": [
     "setuptools"
   ],

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -26493,6 +26493,9 @@
   "vivisect": [
     "setuptools"
   ],
+  "viztracer": [
+    "setuptools"
+  ],
   "vmprof": [
     "setuptools"
   ],

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3940,6 +3940,17 @@ lib.composeManyExtensions [
         }
       );
 
+      pye3d = prev.pye3d.overridePythonAttrs (old: {
+        buildInputs = old.buildInputs or [ ]
+          ++ [ pkgs.eigen final.scikit-build ];
+
+        postPatch = ''
+          sed -i "2i version = ${old.version}" setup.cfg
+        '';
+
+        dontUseCmakeConfigure = true;
+      });
+
       # pyee cannot find `vcversioner` and other "setup requirements", so it tries to
       # download them from the internet, which only works when nix sandboxing is disabled.
       # Additionally, since pyee uses vcversioner to specify its version, we need to do this


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
