### PR TITLE
fix(overrides): update build systems for a handful of django packages

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -5286,6 +5286,9 @@
   "django-braces": [
     "setuptools"
   ],
+  "django-browser-reload": [
+    "setuptools"
+  ],
   "django-cache-memoize": [
     "setuptools"
   ],
@@ -5471,6 +5474,9 @@
   "django-libsass": [
     "setuptools"
   ],
+  "django-lifecycle": [
+    "setuptools"
+  ],
   "django-logentry-admin": [
     "setuptools"
   ],
@@ -5616,6 +5622,9 @@
   "django-scopes": [
     "setuptools"
   ],
+  "django-sendgrid-v5": [
+    "setuptools"
+  ],
   "django-ses": [
     "setuptools"
   ],
@@ -5666,9 +5675,15 @@
   "django-tastypie": [
     "setuptools"
   ],
+  "django-template-partials": [
+    "flit-core"
+  ],
   "django-timezone-field": [
     "poetry-core",
     "setuptools"
+  ],
+  "django-tree-queries": [
+    "hatchling"
   ],
   "django-treebeard": [
     "setuptools"
@@ -7591,6 +7606,8 @@
     "setuptools"
   ],
   "fsspec": [
+    "hatch-vcs",
+    "hatchling",
     "setuptools"
   ],
   "fsspec-xrootd": [


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

When trying to migrate a large Django project I have to nix I ran into errors for builds here. I tested this by pointing my Django project at my local directory while developing and adding the required build systems for each package.
