### PR TITLE
overrides: add mss 9.0.2+, ffmpegcv

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -12424,7 +12424,14 @@
     "setuptools"
   ],
   "mss": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "9.0.2"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "9.0.2"
+    }
   ],
   "mt-940": [
     "setuptools"

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -6910,6 +6910,9 @@
   "ffmpeg-python": [
     "setuptools"
   ],
+  "ffmpegcv": [
+    "setuptools"
+  ],
   "ffmpy": [
     "setuptools"
   ],


### PR DESCRIPTION
See: https://github.com/BoboTiG/python-mss/releases/tag/v9.0.2

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
