### PR TITLE
[fix] change path to defaultPoetryOverrides in the doc

### DIFF
--- a/docs/edgecases.md
+++ b/docs/edgecases.md
@@ -127,7 +127,7 @@ In order to be able to build `django-floppyforms` we should modify our nix defin
 ``` nix
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
-  overrides = poetry2nix.defaultPoetryOverrides.extend
+  overrides = poetry2nix.lib.mkPoetry2Nix.defaultPoetryOverrides.extend
     (final: prev: {
       django-floppyforms = prev.django-floppyforms.overridePythonAttrs
       (
@@ -149,7 +149,7 @@ Your file might then look something like this:
 ``` nix
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
-  overrides = poetry2nix.defaultPoetryOverrides.extend
+  overrides = poetry2nix.lib.mkPoetry2Nix.defaultPoetryOverrides.extend
     (final: prev: {
       first-dependency = prev.first-dependency.overridePythonAttrs
       (
@@ -180,7 +180,7 @@ let
     simpervisor = [ "setuptools" ];
     pandas = [ "versioneer" ];
   };
-  p2n-overrides = p2n.defaultPoetryOverrides.extend (final: prev:
+  p2n-overrides = p2n.lib.mkPoetry2Nix.defaultPoetryOverrides.extend (final: prev:
     builtins.mapAttrs (package: build-requirements:
       (builtins.getAttr package prev).overridePythonAttrs (old: {
         buildInputs = (old.buildInputs or [ ]) ++ (builtins.map (pkg: if builtins.isString pkg then builtins.getAttr pkg prev else pkg) build-requirements);


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

Having tried to override a buildInputs according to the edgecase documentation, I was confronted to this error : 

```
       error: attribute 'defaultPoetryOverrides' missing
```

I then found [this question](https://discourse.nixos.org/t/need-help-on-moving-python-poetry-project-to-flake-nix/41356) to which someone suggested to use "poetry2nix.lib.mkPoetry2Nix.defaultPoetryOverrides instead of poetry2nix.defaultPoetryOverrides" 

It did work for me, so I'm creating this PR but is this the way it should be handled ? or would you suggest another solution ?