### PR TITLE
overrides wxpython

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -4139,6 +4139,8 @@ lib.composeManyExtensions [
             setuptools
             numpy
             six
+            attrdict
+            sip
           ]);
         in
         {


### PR DESCRIPTION
Need `attrdict`,`sip` to build wxpython 4.2.0

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
