### PR TITLE
fix(overrides): propcache

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -16216,6 +16216,11 @@
   "prompthub-py": [
     "poetry-core"
   ],
+  "propcache": [
+    "cython",
+    "expandvars",
+    "setuptools"
+  ],
   "property-manager": [
     "setuptools"
   ],


### PR DESCRIPTION
looks like since yesterday yarl (used by aiohttp) needs this package and next version of aiohttp will depend on it as well

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
