### PR TITLE
fix(overrides): logging-json uses setuptools

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11258,6 +11258,9 @@
   "logging-journald": [
     "poetry-core"
   ],
+  "logging-json": [
+    "setuptools"
+  ],
   "logi-circle": [
     "setuptools"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
