### PR TITLE
feat(luaparser): override build-systems

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -11362,6 +11362,9 @@
   "lsprotocol": [
     "flit-core"
   ],
+  "luaparser": [
+    "setuptools"
+  ],
   "luddite": [
     "setuptools"
   ],


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"


Sorry for the "it works for my machine" but I don't think it get any more complicated than this

<details>

<summary>Original error</summary>

```
error: builder for '/nix/store/hqm1fpycm4q5arr9bksa22ly207rrcha-python3.12-luaparser-3.2.1.drv' failed with exit code 2;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
       >   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
       > ModuleNotFoundError: No module named 'setuptools'
       > 
       > 
       For full logs, run 'nix log /nix/store/hqm1fpycm4q5arr9bksa22ly207rrcha-python3.12-luaparser-3.2.1.drv'.
error: 1 dependencies of derivation '/nix/store/nzqp9ax6lqqj12p3pslnrs7bhxayj4ji-python3-3.12.6-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/3vfm2k526lwdhjlz72pzxq8n6iymmvpp-nix-shell-env.drv' failed to build
```

</details>


<details>

<summary>Repository setup</summary>

```nix
# flake.nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
  inputs.poetry2nix.url = "github:pegasust/poetry2nix/pylua-parser";
  inputs.poetry2nix.inputs.nixpkgs.follows = "nixpkgs";

  nixConfig = {
    # allow-import-from-derivation = true;
    experimental-features = ["nix-command" "flakes"];
  };

  outputs = {
    self,
    nixpkgs,
    ...
  } @ inputs: let
    systems = ["aarch64-darwin" "x86_64-linux"];
    eachSystemCtx = f: (nixpkgs.lib.genAttrs systems (sys: f (let
      pkgs = import nixpkgs {system=sys;};
    in {
      inherit inputs sys pkgs self;
      poetry2nix = inputs.poetry2nix.lib.mkPoetry2Nix {inherit pkgs;};
      outputs = self;
    })));

    poetry = ctx@{pkgs,...}: pkgs.poetry;
  in {
    packages = eachSystemCtx (ctx@{sys, pkgs, poetry2nix, outputs, ...}: {
      poetry = poetry ctx;
      root-pyproject-packages = poetry2nix.mkPoetryEnv {
        projectDir = self;
      };
      
      py-scripts = poetry2nix.mkPoetryScriptsPackage {
        projectDir = self;
      };
    });

    devShells = eachSystemCtx ({sys, pkgs, outputs,...}: {
      default = pkgs.mkShell {
        packages = [
          outputs.packages.${sys}.root-pyproject-packages
        ];
      };
    });

    checks = eachSystemCtx ({sys, pkgs, outputs, ...}: {
      # TODO: WIP, need testing
      poetry-lock = pkgs.writeShellScriptBin "check-poetry-lock" ''
        ${pkgs.lib.getBin pkgs.nix}/bin/nix run .#poetry -- check --lock
        exit_code=''$?
        exit $exit_code
      '';

      pull-no-subgit = outputs.packages.${sys}.validate-no-git;
    });

    ci-mutate = eachSystemCtx ({sys, pkgs, outputs,...}: {
      maintain-poetry-lock = pkgs.writeShellScriptBin "maintain-poetry-lock" ''
        ${outputs.packages.${sys}.poetry}/bin/poetry lock --no-update
      '';

    });
  };

}
```

`pyproject.toml` is as follow

```toml
[tool.poetry]
name = "luaparser-test"
version = "0.0.1"
description="test luaparser"
authors = ["Pegasust <pegasucksgg@gmail.com"]
readme = "README.md"

[tool.poetry.dependencies]
python = "^3.10"
luaparser = "^3.2.1"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"
```
`poetry.lock`
```toml
# This file is automatically @generated by Poetry 1.8.4 and should not be changed by hand.

[[package]]
name = "antlr4-python3-runtime"
version = "4.7.2"
description = "ANTLR 4.7.2 runtime for Python 3.6.3"
optional = false
python-versions = "*"
files = [
    {file = "antlr4-python3-runtime-4.7.2.tar.gz", hash = "sha256:168cdcec8fb9152e84a87ca6fd261b3d54c8f6358f42ab3b813b14a7193bb50b"},
]

[[package]]
name = "luaparser"
version = "3.2.1"
description = "A lua parser in Python"
optional = false
python-versions = "*"
files = [
    {file = "luaparser-3.2.1-py3-none-any.whl", hash = "sha256:d6d45953f008110b65e406867ecc2390ab109250d34383fe82931c45e02cff71"},
    {file = "luaparser-3.2.1.tar.gz", hash = "sha256:ee817a59ce42fdfa91997a25b9db9b1a4191aee548c2379e36a348e2e9025269"},
]

[package.dependencies]
antlr4-python3-runtime = "<=4.7.2"

[metadata]
lock-version = "2.0"
python-versions = "^3.10"
content-hash = "94bee527a2d5289493933bbc306be513db2e28681540a36bbd4c22574725c3e0"
```

</details>

Execution "proof" after change

```console
% ❯ nix run nixpkgs#poetry -- lock --no-update
% ❯ git add .
% ❯ nix flake lock
% ❯ nix develop .#default -c python

```