### PR TITLE
chore(deps): bump flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720066371,
-        "narHash": "sha256-uPlLYH2S0ACj0IcgaK9Lsf4spmJoGejR9DotXiXSBZQ=",
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "622f829f5fe69310a866c8a6cd07e747c44ef820",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727984844,
-        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728228884,
-        "narHash": "sha256-E9JaDKGi21oUypH0P9881lbkhi6USNJ6XL2tFzU5uuE=",
+        "lastModified": 1730157240,
+        "narHash": "sha256-P8wF4ag6Srmpb/gwskYpnIsnspbjZlRvu47iN527ABQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff0da78cfd41aa1784910ce1fea89119822013ce",
+        "rev": "75e28c029ef2605f9841e0baa335d70065fe7ae2",
         "type": "github"
       },
       "original": {

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3891,14 +3891,6 @@ lib.composeManyExtensions [
         }
       );
 
-      # The tokenizers build requires a complex rust setup (cf. nixpkgs override)
-      #
-      # Instead of providing a full source build, we use a wheel to keep
-      # the complexity manageable for now.
-      tokenizers = prev.tokenizers.override {
-        preferWheel = true;
-      };
-
       torch = prev.torch.overridePythonAttrs (old: {
         # torch has an auto-magical way to locate the cuda libraries from site-packages.
         autoPatchelfIgnoreMissingDeps = true;

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2790,11 +2790,7 @@ lib.composeManyExtensions [
 
       pyqt6 =
         let
-          # The build from source fails unless the pyqt6 version agrees
-          # with the version of qt6 from nixpkgs. Thus, we prefer using
-          # the wheel here.
-          pyqt6-wheel = prev.pyqt6.override { preferWheel = true; };
-          pyqt6 = pyqt6-wheel.overridePythonAttrs (old:
+          pyqt6 = prev.pyqt6.overridePythonAttrs (old:
             let
               confirm-license = pkgs.writeText "confirm-license.patch" ''
                 diff --git a/project.py b/project.py

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3147,7 +3147,7 @@ lib.composeManyExtensions [
       pyzmq = prev.pyzmq.overridePythonAttrs (
         old: {
           nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ pkg-config ];
-          propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ pkgs.zeromq ];
+          propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ pkgs.zeromq pkgs.libsodium ];
           # setting dontUseCmakeConfigure is necessary because:
           #
           # 1. pyzmq uses scikit-build-core as of pyzmq version 26.0.0

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2144,8 +2144,15 @@ lib.composeManyExtensions [
         propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ final.pyutilib ];
       });
 
-      paramiko = prev.paramiko.overridePythonAttrs (_: {
+      paramiko = prev.paramiko.overridePythonAttrs (old: {
         doCheck = false; # requires networking
+
+        optional-dependencies = old.optional-dependencies or {
+          ed25519 = [
+            final.pynacl
+            final.bcrypt
+          ];
+        };
       });
 
       parsel = prev.parsel.overridePythonAttrs (


### PR DESCRIPTION
- **fix(pyzmq): add new libsodium runtime dependency**
- **chore: remove use of now-invalid override of tokenizers**
- **chore: remove use of now-invalid override from pyqt6**
- **chore: work around missing optional-dependencies attribute**
- **chore(deps): bump nix-github-actions**
- **chore(deps): bump nixpkgs**
- **chore(deps): bump treefmt-nix**

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [x] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
