### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Creates a Python application using the Python interpreter specified based on the
 - **meta**: application [meta](https://nixos.org/nixpkgs/manual/#chap-meta) data (_default:_ `{}`).
 - **python**: The Python interpreter to use (_default:_ `pkgs.python3`).
 - **preferWheels** : Use wheels rather than sdist as much as possible (_default_: `false`).
-- **groups**: Which Poetry 1.2.0+ dependency groups to install (_default_: `[ ]`).
+- **groups**: Which Poetry 1.2.0+ dependency groups to install (_default_: `[ "main" ]`).
 - **checkGroups**: Which Poetry 1.2.0+ dependency groups to install (independently of **groups**) to run unit tests (_default_: `[ "dev" ]`).
 - **extras**: Which Poetry `extras` to install (_default_: `[ "*" ]`, all extras).
 
@@ -216,7 +216,7 @@ Creates an environment that provides a Python interpreter along with all depende
 - **editablePackageSources**: A mapping from package name to source directory, these will be installed in editable mode. Note that path dependencies with `develop = true` will be installed in editable mode unless explicitly passed to `editablePackageSources` as `null`.  (_default:_ `{}`).
 - **extraPackages**: A function taking a Python package set and returning a list of extra packages to include in the environment. This is intended for packages deliberately not added to `pyproject.toml` that you still want to include. An example of such a package may be `pip`. (_default:_ `(ps: [ ])`).
 - **preferWheels** : Use wheels rather than sdist as much as possible (_default_: `false`).
-- **groups**: Which Poetry 1.2.0+ dependency groups to install (_default_: `[ "dev" ]`).
+- **groups**: Which Poetry 1.2.0+ dependency groups to install (_default_: `[ "main" "dev" ]`).
 - **checkGroups**: Which Poetry 1.2.0+ dependency groups to install (independently of **groups**) to run unit tests (_default_: `[ "dev" ]`).
 - **extras**: Which Poetry `extras` to install (_default_: `[ "*" ]`, all extras).
 


### PR DESCRIPTION
Set correct default values for the 'groups' parameter of mkPoetryApplication and mkPoetryEnv.

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
