### PR TITLE
overrides: add setup for torchaudio

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3905,6 +3905,19 @@ lib.composeManyExtensions [
         ];
       });
 
+      torchaudio = prev.torchaudio.overridePythonAttrs (old: {
+        autoPatchelfIgnoreMissingDeps = true;
+
+        # (no patchelf on darwin, since no elves there.)
+        preFixup = lib.optionals (!stdenv.isDarwin) ''
+          addAutoPatchelfSearchPath "${final.torch}/${final.python.sitePackages}/torch/lib"
+        '';
+
+        buildInputs = old.buildInputs or [ ] ++ [
+          final.torch
+        ];
+      });
+
       torchvision = prev.torchvision.overridePythonAttrs (old: {
         autoPatchelfIgnoreMissingDeps = true;
 


### PR DESCRIPTION
[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
