### PR TITLE
overrides: fix pyside6

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -2949,6 +2949,9 @@ lib.composeManyExtensions [
           pkgs.xorg.libxshmfence
           pkgs.xorg.libxkbfile
         ];
+        postInstall = ''
+          rm -r $out/${final.python.sitePackages}/PySide6/__pycache__/
+        '';
       });
       pyside6 = prev.pyside6.overridePythonAttrs (_old: {
         # The PySide6/__init__.py script tries to find the Qt libraries
@@ -2963,6 +2966,7 @@ lib.composeManyExtensions [
         postFixup = ''
           ${pkgs.xorg.lndir}/bin/lndir ${final.pyside6-essentials}/${final.python.sitePackages}/PySide6 $out/${final.python.sitePackages}/PySide6
           ${pkgs.xorg.lndir}/bin/lndir ${final.pyside6-addons}/${final.python.sitePackages}/PySide6 $out/${final.python.sitePackages}/PySide6
+          rm -r $out/${final.python.sitePackages}/PySide6/__pycache__/
         '';
       });
 


### PR DESCRIPTION
Clean the `__pycache__` folder to avoid collisions between `pyside6`, `pyside6-addons`, and `pyside6-essentials`.

Related to: https://github.com/nix-community/poetry2nix/pull/1808

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
