### PR TITLE
fix: rm overwrite for eth-utils

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -882,9 +882,6 @@ lib.composeManyExtensions [
         '';
       };
 
-      # FIXME: this is a workaround for https://github.com/nix-community/poetry2nix/issues/1161
-      eth-utils = prev.eth-utils.override { preferWheel = true; };
-
       evdev = prev.evdev.overridePythonAttrs (_old: {
         preConfigure = ''
           substituteInPlace setup.py --replace-warn /usr/include/linux ${pkgs.linuxHeaders}/include/linux


### PR DESCRIPTION
to avoid attribute 'override' missing error when bump nixpkgs to 25.05, for more [info](https://github.com/crypto-org-chain/ethermint/pull/569/files)

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
