### PR TITLE
Remove Leaked `indirect` Input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,8 +88,9 @@
         "type": "github"
       },
       "original": {
-        "id": "systems",
-        "type": "indirect"
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,8 @@
       url = "github:nix-community/nix-github-actions";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =


### PR DESCRIPTION
Removes the leaked indirect `inputs.systems`. This created an ambiguous and indirect lockfile entry, this is resolved with this PR, which creates a clear `original` entry with fields similar to the `locked` entry. 

Furthermore, not having it marked as an input is not inline with the examples of the `nix-systems` project found [here](https://github.com/nix-systems/nix-systems/blob/main/examples/simple/flake.nix#L4). 

[Contribution](README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
