### PR TITLE
overrides: Fix isort 5.13.2; Add icalendar 6.0.0

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9912,11 +9912,11 @@
   "isort": [
     {
       "buildSystem": "poetry-core",
-      "until": "5.13.2"
+      "until": "6.0.0"
     },
     {
       "buildSystem": "setuptools",
-      "until": "5.13.2"
+      "until": "6.0.0"
     },
     {
       "buildSystem": "hatch-vcs",

--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -9426,7 +9426,18 @@
     "setuptools"
   ],
   "icalendar": [
-    "setuptools"
+    {
+      "buildSystem": "setuptools",
+      "until": "6.0.0"
+    },
+    {
+      "buildSystem": "hatch-vcs",
+      "from": "6.0.0"
+    },
+    {
+      "buildSystem": "hatchling",
+      "from": "6.0.0"
+    }
   ],
   "icalevents": [
     "poetry-core"


### PR DESCRIPTION
* icalendar uses hatchling/hatch-vcs since 6.0.0
* `until` version constraints in `build-systems.json` are _exclusive_, so isort 5.13.2 was broken after change b0b33d45

[Contribution](https://github.com/nix-community/poetry2nix/blob/master/README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](https://github.com/nix-community/poetry2nix/blob/master/tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
