### PR TITLE
 overrides: add cargo hash for bcrypt 4.3.0

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -363,6 +363,7 @@ lib.composeManyExtensions [
             "4.1.3" = "sha256-Uag1pUuis5lpnus2p5UrMLa4HP7VQLhKxR5TEMfpK0s=";
             "4.2.0" = "sha256-dOS9A3pTwXYkzPFFNh5emxJw7pSdDyY+mNIoHdwNdmg=";
             "4.2.1" = "sha256-vbGF0oOhEDg3QIyQ0lASqbWtTWXiPAmGMnlF9I+hU78=";
+            "4.3.0" = "sha256-92MEpnrUhdqpgMuXicy9c5gfdXYY0eq5Ak9fvNXAgMk=";
           }.${version} or (
             lib.warn "Unknown bcrypt version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
[Contribution](https://github.com/nix-community/poetry2nix/blob/master/README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](https://github.com/nix-community/poetry2nix/blob/master/tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"

Fixes:
```
evaluation warning: rustPlatform.fetchCargoTarball is deprecated in favor of rustPlatform.fetchCargoVendor.
                    If you are using buildRustPackage, try setting useFetchCargoVendor = true and regenerating cargoHash.
                    See the 25.05 release notes for more information.
evaluation warning: Unknown bcrypt version: '4.3.0'. Please update getCargoHash.
[1/1/67 built] building bcrypt-4.3.0-vendor.tar.gz (buildPhase):   Downloaded syn v2.0.98
error: hash mismatch in fixed-output derivation '/nix/store/rfsq5h4pk0lc4hnb6670xdmaigbgv8ly-bcrypt-4.3.0-vendor.tar.gz.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-92MEpnrUhdqpgMuXicy9c5gfdXYY0eq5Ak9fvNXAgMk=
error: 1 dependencies of derivation '/nix/store/a60ia7pnhnxfvis5g987jd6j59zqzwhn-python3.12-bcrypt-4.3.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/40vnmm3w68qmdamli6ivapqilfnmsbdx-python3-3.12.9-env.drv' failed to build
```
