### PR TITLE
Cleanup flake

### DIFF
--- a/actions.nix
+++ b/actions.nix
@@ -43,11 +43,12 @@ nix-github-actions.lib.mkGithubMatrix {
       in
       {
         # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
-        aggregate = pkgs.runCommand "darwin-aggregate" {
-          env.TEST_INPUTS = lib.concatStringsSep " " (
-            lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
-          );
-        } "touch $out";
+        aggregate = pkgs.runCommand "darwin-aggregate"
+          {
+            env.TEST_INPUTS = lib.concatStringsSep " " (
+              lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
+            );
+          } "touch $out";
       };
     aarch64-darwin =
       let
@@ -57,11 +58,12 @@ nix-github-actions.lib.mkGithubMatrix {
       in
       {
         # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
-        aggregate = pkgs.runCommand "darwin-aggregate" {
-          env.TEST_INPUTS = lib.concatStringsSep " " (
-            lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
-          );
-        } "touch $out";
+        aggregate = pkgs.runCommand "darwin-aggregate"
+          {
+            env.TEST_INPUTS = lib.concatStringsSep " " (
+              lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
+            );
+          } "touch $out";
       };
   };
 }

--- a/actions.nix
+++ b/actions.nix
@@ -1,0 +1,68 @@
+{ inputs, self }:
+
+let
+  inherit (inputs) nixpkgs nix-github-actions treefmt-nix;
+
+  systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  treefmtEval = f: nixpkgs.lib.genAttrs systems (system: f (
+    treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} ./dev/treefmt.nix
+  ));
+
+  mkPkgs =
+    system:
+    import nixpkgs {
+      config = {
+        allowAliases = false;
+        allowInsecurePredicate = _: true;
+      };
+      overlays = [ self.overlays.default ];
+      inherit system;
+    };
+in
+nix-github-actions.lib.mkGithubMatrix {
+  platforms = {
+    "x86_64-linux" = "ubuntu-22.04";
+    "x86_64-darwin" = "macos-13";
+    "aarch64-darwin" = "macos-14";
+  };
+  checks = {
+    x86_64-linux =
+      let
+        pkgs = mkPkgs "x86_64-linux";
+      in
+      import ./tests { inherit pkgs; }
+      // {
+        formatting = treefmtEval.x86_64-linux.config.build.check self;
+      };
+
+    x86_64-darwin =
+      let
+        pkgs = mkPkgs "x86_64-darwin";
+        inherit (pkgs) lib;
+        tests = import ./tests { inherit pkgs; };
+      in
+      {
+        # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
+        aggregate = pkgs.runCommand "darwin-aggregate" {
+          env.TEST_INPUTS = lib.concatStringsSep " " (
+            lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
+          );
+        } "touch $out";
+      };
+    aarch64-darwin =
+      let
+        pkgs = mkPkgs "aarch64-darwin";
+        inherit (pkgs) lib;
+        tests = import ./tests { inherit pkgs; };
+      in
+      {
+        # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
+        aggregate = pkgs.runCommand "darwin-aggregate" {
+          env.TEST_INPUTS = lib.concatStringsSep " " (
+            lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
+          );
+        } "touch $out";
+      };
+  };
+}
+

--- a/dev/treefmt.nix
+++ b/dev/treefmt.nix
@@ -26,6 +26,7 @@
   };
 
   programs.deadnix.enable = true;
+  programs.nixpkgs-fmt.enable = true;
   programs.statix.enable = true;
   programs.black.enable = true;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -59,26 +59,10 @@
         "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -56,25 +38,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
           poetry = {
             # https://wiki.nixos.org/wiki/Flakes
             type = "app";
-            program = "${pkgs.poetry}/bin/poetry";
+            program = lib.getExe pkgs.poetry;
           };
         });
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,10 @@
     let
       inherit (nixpkgs) lib;
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
-      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix);
+
+      forAllSystems = f: lib.genAttrs
+        systems
+        (system: f nixpkgs.legacyPackages.${system});
     in
     {
       overlays.default = lib.composeManyExtensions [ (import ./overlay.nix) ];
@@ -41,55 +43,57 @@
         };
         default = self.templates.app;
       };
-    }
-    // (flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          config.allowAliases = false;
-        };
 
-        poetry2nix = import ./default.nix { inherit pkgs; };
-        p2nix-tools = pkgs.callPackage ./tools { inherit poetry2nix; };
-      in
-      {
-        formatter = treefmtEval.${system}.config.build.wrapper;
+      formatter = forAllSystems (pkgs:
+        let
+          treefmtEval = treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix;
+        in
+        treefmtEval.config.build.wrapper);
 
-        packages = {
+      packages = forAllSystems (pkgs:
+        let
+          poetry2nix = self.lib.mkPoetry2Nix { inherit pkgs; };
+        in
+        {
           poetry2nix = poetry2nix.cli;
           default = poetry2nix.cli;
-        };
+        });
 
-        devShells = {
+      apps = forAllSystems (pkgs:
+        let
+          poetry2nix = self.lib.mkPoetry2Nix { inherit pkgs; };
+          app = flake-utils.lib.mkApp { drv = poetry2nix.env; };
+        in
+        {
+          poetry = {
+            # https://wiki.nixos.org/wiki/Flakes
+            type = "app";
+            program = "${pkgs.poetry}/bin/poetry";
+          };
+          poetry2nix = app;
+          default = app;
+        });
+
+      devShells = forAllSystems (pkgs:
+        let
+          poetry2nix = self.lib.mkPoetry2Nix { inherit pkgs; };
+          p2nix-tools = pkgs.callPackage ./tools { inherit poetry2nix; };
+        in
+        {
           default = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [
+            nativeBuildInputs = [
               p2nix-tools.env
               p2nix-tools.flamegraph
-              nixpkgs-fmt
-              poetry
-              niv
-              jq
-              nix-prefetch-git
-              nix-eval-jobs
-              nix-build-uncached
+
+              pkgs.nixpkgs-fmt
+              pkgs.poetry
+              pkgs.niv
+              pkgs.jq
+              pkgs.nix-prefetch-git
+              pkgs.nix-eval-jobs
+              pkgs.nix-build-uncached
             ];
           };
-        };
-
-        apps =
-          let
-            app = flake-utils.lib.mkApp { drv = poetry2nix.cli; };
-          in
-          {
-            poetry = {
-              # https://wiki.nixos.org/wiki/Flakes
-              type = "app";
-              program = "${pkgs.poetry}/bin/poetry";
-            };
-            poetry2nix = app;
-            default = app;
-          };
-      }
-    ));
+        });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,9 @@
       self,
       nixpkgs,
       flake-utils,
-      nix-github-actions,
       treefmt-nix,
-    }:
+      ...
+    } @ inputs:
     let
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
       eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
@@ -32,65 +32,7 @@
       overlays.default = nixpkgs.lib.composeManyExtensions [ (import ./overlay.nix) ];
       lib.mkPoetry2Nix = { pkgs }: import ./default.nix { inherit pkgs; };
 
-      githubActions =
-        let
-          mkPkgs =
-            system:
-            import nixpkgs {
-              config = {
-                allowAliases = false;
-                allowInsecurePredicate = _: true;
-              };
-              overlays = [ self.overlays.default ];
-              inherit system;
-            };
-        in
-        nix-github-actions.lib.mkGithubMatrix {
-          platforms = {
-            "x86_64-linux" = "ubuntu-22.04";
-            "x86_64-darwin" = "macos-13";
-            "aarch64-darwin" = "macos-14";
-          };
-          checks = {
-            x86_64-linux =
-              let
-                pkgs = mkPkgs "x86_64-linux";
-              in
-              import ./tests { inherit pkgs; }
-              // {
-                formatting = treefmtEval.x86_64-linux.config.build.check self;
-              };
-
-            x86_64-darwin =
-              let
-                pkgs = mkPkgs "x86_64-darwin";
-                inherit (pkgs) lib;
-                tests = import ./tests { inherit pkgs; };
-              in
-              {
-                # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
-                aggregate = pkgs.runCommand "darwin-aggregate" {
-                  env.TEST_INPUTS = lib.concatStringsSep " " (
-                    lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
-                  );
-                } "touch $out";
-              };
-            aarch64-darwin =
-              let
-                pkgs = mkPkgs "aarch64-darwin";
-                inherit (pkgs) lib;
-                tests = import ./tests { inherit pkgs; };
-              in
-              {
-                # Aggregate all tests into one derivation so that only one GHA runner is scheduled for all darwin jobs
-                aggregate = pkgs.runCommand "darwin-aggregate" {
-                  env.TEST_INPUTS = lib.concatStringsSep " " (
-                    lib.attrValues (lib.filterAttrs (_: v: lib.isDerivation v) tests)
-                  );
-                } "touch $out";
-              };
-          };
-        };
+      githubActions = import ./actions.nix { inherit inputs self; };
 
       templates = {
         app = {

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
         poetry2nix = import ./default.nix { inherit pkgs; };
         p2nix-tools = pkgs.callPackage ./tools { inherit poetry2nix; };
       in
-      rec {
+      {
         formatter = treefmtEval.${system}.config.build.wrapper;
 
         packages = {
@@ -135,14 +135,17 @@
           };
         };
 
-        apps = {
+        apps = let
+          app = flake-utils.lib.mkApp { drv = poetry2nix.cli; };
+        in
+        {
           poetry = {
             # https://wiki.nixos.org/wiki/Flakes
             type = "app";
             program = "${pkgs.poetry}/bin/poetry";
           };
-          poetry2nix = flake-utils.lib.mkApp { drv = packages.poetry2nix; };
-          default = apps.poetry2nix;
+          poetry2nix = app;
+          default = app;
         };
       }
     ));

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,13 @@
       ...
     } @ inputs:
     let
+      inherit (nixpkgs) lib;
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix);
     in
     {
-      overlays.default = nixpkgs.lib.composeManyExtensions [ (import ./overlay.nix) ];
+      overlays.default = lib.composeManyExtensions [ (import ./overlay.nix) ];
       lib.mkPoetry2Nix = { pkgs }: import ./default.nix { inherit pkgs; };
 
       githubActions = import ./actions.nix { inherit inputs self; };

--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,6 @@
       url = "github:nix-community/nix-github-actions";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    systems.url = "github:nix-systems/default";
   };
 
   outputs =
@@ -24,10 +22,10 @@
       flake-utils,
       nix-github-actions,
       treefmt-nix,
-      systems,
     }:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./dev/treefmt.nix);
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "Poetry2nix flake";
 
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
     # Last working commit from nixos-small-unstable
     nixpkgs.url = "github:NixOS/nixpkgs?rev=75e28c029ef2605f9841e0baa335d70065fe7ae2";
 
@@ -18,7 +17,6 @@
   outputs =
     { self
     , nixpkgs
-    , flake-utils
     , treefmt-nix
     , ...
     } @ inputs:
@@ -29,6 +27,18 @@
       forAllSystems = f: lib.genAttrs
         systems
         (system: f nixpkgs.legacyPackages.${system});
+
+      # Taking the mkApp functionality from flake-utils, so we don't need it
+      # as a dependency
+      mkApp =
+        { drv
+        , name ? drv.pname or drv.name
+        , exePath ? drv.passthru.exePath or "/bin/${name}"
+        }:
+        {
+          type = "app";
+          program = "${drv}${exePath}";
+        };
     in
     {
       overlays.default = lib.composeManyExtensions [ (import ./overlay.nix) ];
@@ -62,16 +72,18 @@
       apps = forAllSystems (pkgs:
         let
           poetry2nix = self.lib.mkPoetry2Nix { inherit pkgs; };
-          app = flake-utils.lib.mkApp { drv = poetry2nix.env; };
+
+          default = mkApp { drv = poetry2nix.env; };
         in
         {
+          inherit default;
+          poetry2nix = default;
+
           poetry = {
             # https://wiki.nixos.org/wiki/Flakes
             type = "app";
             program = "${pkgs.poetry}/bin/poetry";
           };
-          poetry2nix = app;
-          default = app;
         });
 
       devShells = forAllSystems (pkgs:

--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,11 @@
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-      treefmt-nix,
-      ...
+    { self
+    , nixpkgs
+    , flake-utils
+    , treefmt-nix
+    , ...
     } @ inputs:
     let
       inherit (nixpkgs) lib;
@@ -78,18 +77,19 @@
           };
         };
 
-        apps = let
-          app = flake-utils.lib.mkApp { drv = poetry2nix.cli; };
-        in
-        {
-          poetry = {
-            # https://wiki.nixos.org/wiki/Flakes
-            type = "app";
-            program = "${pkgs.poetry}/bin/poetry";
+        apps =
+          let
+            app = flake-utils.lib.mkApp { drv = poetry2nix.cli; };
+          in
+          {
+            poetry = {
+              # https://wiki.nixos.org/wiki/Flakes
+              type = "app";
+              program = "${pkgs.poetry}/bin/poetry";
+            };
+            poetry2nix = app;
+            default = app;
           };
-          poetry2nix = app;
-          default = app;
-        };
       }
     ));
 }

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -3175,8 +3175,9 @@ lib.composeManyExtensions [
       );
       pyyaml = prev.pyyaml.overridePythonAttrs (
         old: {
-            buildInputs = old.buildInputs or [ ] ++ [ pkgs.libyaml ];
-      });
+          buildInputs = old.buildInputs or [ ] ++ [ pkgs.libyaml ];
+        }
+      );
 
       pyzmq = prev.pyzmq.overridePythonAttrs (
         old: {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,3 @@
-
 let
   flake = builtins.getFlake "${toString ../.}";
 in
@@ -259,5 +258,5 @@ in
   # sandboxing issue?
   dependency-environment = callTest ./dependency-environment { };
   editable-egg = callTest ./editable-egg { };
-  eth-utils= callTest ./eth-utils { };
+  eth-utils = callTest ./eth-utils { };
 }

--- a/tests/gmsh/default.nix
+++ b/tests/gmsh/default.nix
@@ -1,7 +1,7 @@
-{
-  poetry2nix,
-  python3,
-  runCommand,
+{ poetry2nix
+, python3
+, runCommand
+,
 }:
 let
   env = poetry2nix.mkPoetryEnv {

--- a/tests/ml-stack-old/default.nix
+++ b/tests/ml-stack-old/default.nix
@@ -27,8 +27,8 @@ let
   '';
 in
 # Note: torch.cuda() will print False, even if you have a GPU, when this runs *during test.*
-# But if you run the script below in your shell (rather than during build), it will print True.
-# Presumably this is due to sandboxing.
+  # But if you run the script below in your shell (rather than during build), it will print True.
+  # Presumably this is due to sandboxing.
 runCommand "ml-stack-old-test" { } ''
   ${env}/bin/python "${testScript}" > $out
 ''

--- a/tests/ml-stack/default.nix
+++ b/tests/ml-stack/default.nix
@@ -27,8 +27,8 @@ let
   '';
 in
 # Note: torch.cuda() will print False, even if you have a GPU, when this runs *during test.*
-# But if you run the script below in your shell (rather than during build), it will print True.
-# Presumably this is due to sandboxing.
+  # But if you run the script below in your shell (rather than during build), it will print True.
+  # Presumably this is due to sandboxing.
 runCommand "ml-stack-test" { } ''
   ${env}/bin/python "${testScript}" > $out
 ''

--- a/vendor/pyproject.nix/lib/eggs.nix
+++ b/vendor/pyproject.nix/lib/eggs.nix
@@ -86,14 +86,18 @@ lib.fix (self: {
     let
       inherit (python.passthru) pythonVersion implementation;
 
-      langCompatible = filter (
-        file:
-        file.languageTag.implementation == "python" || file.languageTag.implementation == implementation
-      ) files;
+      langCompatible = filter
+        (
+          file:
+          file.languageTag.implementation == "python" || file.languageTag.implementation == implementation
+        )
+        files;
 
-      versionCompatible = filter (
-        file: compareVersions pythonVersion file.languageTag.version >= 0
-      ) langCompatible;
+      versionCompatible = filter
+        (
+          file: compareVersions pythonVersion file.languageTag.version >= 0
+        )
+        langCompatible;
 
     in
     sort (a: b: compareVersions a.languageTag.version b.languageTag.version > 0) versionCompatible;

--- a/vendor/pyproject.nix/lib/pep440.nix
+++ b/vendor/pyproject.nix/lib/pep440.nix
@@ -96,24 +96,24 @@ let
   # Compare dev/pre/post/local release modifiers
   compareVersionModifier =
     x: y:
-    assert x != null && y != null;
-    let
-      prioX = modifierPriority.${x.type};
-      prioY = modifierPriority.${y.type};
-    in
-    if prioX == prioY then
-      (
-        if x.value == y.value then
-          0
-        else if x.value > y.value then
-          1
-        else
-          -1
-      )
-    else if prioX > prioY then
-      1
-    else
-      0;
+      assert x != null && y != null;
+      let
+        prioX = modifierPriority.${x.type};
+        prioY = modifierPriority.${y.type};
+      in
+      if prioX == prioY then
+        (
+          if x.value == y.value then
+            0
+          else if x.value > y.value then
+            1
+          else
+            -1
+        )
+      else if prioX > prioY then
+        1
+      else
+        0;
 
 in
 fix (self: {
@@ -159,21 +159,23 @@ fix (self: {
         local = mLocalAt 1;
 
         # Parse each post345/dev1 string into attrset
-        modifiers = map (
-          mod:
-          let
-            # Split post345 into ["post" "345"]
-            m = match "-?([^0-9]+)([0-9]+)" mod;
-          in
-          if m == null then
-            throw "PEP-440 modifier segment invalid: ${mod}"
-          # assert m != null;
-          else
-            {
-              type = normalizedReleaseType (elemAt m 0);
-              value = toIntRelease (elemAt m 1);
-            }
-        ) (filter (s: isString s && s != "") (split "\\." modifiersSegment));
+        modifiers = map
+          (
+            mod:
+            let
+              # Split post345 into ["post" "345"]
+              m = match "-?([^0-9]+)([0-9]+)" mod;
+            in
+            if m == null then
+              throw "PEP-440 modifier segment invalid: ${mod}"
+            # assert m != null;
+            else
+              {
+                type = normalizedReleaseType (elemAt m 0);
+                value = toIntRelease (elemAt m 1);
+              }
+          )
+          (filter (s: isString s && s != "") (split "\\." modifiersSegment));
 
       in
       if tokens == null || mLocal == null then
@@ -368,21 +370,21 @@ fix (self: {
         eq = self.comparators."==";
       in
       a: b:
-      (
-        # Local version identifiers are NOT permitted in this version specifier.
-        assert a.local == null && b.local == null;
-        gte a b
-        && eq a (
-          b
-          // {
-            release = sublist 0 ((length b.release) - 1) b.release;
-            # If a pre-release, post-release or developmental release is named in a compatible release clause as V.N.suffix, then the suffix is ignored when determining the required prefix match.
-            pre = null;
-            post = null;
-            dev = null;
-          }
-        )
-      );
+        (
+          # Local version identifiers are NOT permitted in this version specifier.
+          assert a.local == null && b.local == null;
+          gte a b
+          && eq a (
+            b
+            // {
+              release = sublist 0 ((length b.release) - 1) b.release;
+              # If a pre-release, post-release or developmental release is named in a compatible release clause as V.N.suffix, then the suffix is ignored when determining the required prefix match.
+              pre = null;
+              post = null;
+              dev = null;
+            }
+          )
+        );
     "==" = a: b: self.compareVersions a b == 0;
     "!=" = a: b: self.compareVersions a b != 0;
     "<=" = a: b: self.compareVersions a b <= 0;

--- a/vendor/pyproject.nix/lib/pep508.nix
+++ b/vendor/pyproject.nix/lib/pep508.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  pep508,
-  pep440,
-  pep599,
-  pypa,
-  ...
+{ lib
+, pep508
+, pep440
+, pep599
+, pypa
+, ...
 }:
 
 let
@@ -84,11 +83,11 @@ let
       "sys_platform" = default;
       "extra" =
         value:
-        assert isList value || isString value;
-        {
-          type = "extra";
-          inherit value;
-        };
+          assert isList value || isString value;
+          {
+            type = "extra";
+            inherit value;
+          };
     };
 
   # Comparators for simple equality
@@ -152,20 +151,22 @@ let
   # Copied from nixpkgs lib.findFirstIndex internals to save on a little bit of environment allocations.
   resultIndex' =
     pred:
-    foldl' (
-      index: el:
-      if index < 0 then
+    foldl'
+      (
+        index: el:
+        if index < 0 then
         # No match yet before the current index, we need to check the element
-        if pred el then
+          if pred el then
           # We have a match! Turn it into the actual index to prevent future iterations from modifying it
-          -index - 1
-        else
+            -index - 1
+          else
           # Still no match, update the index to the next element (we're counting down, so minus one)
-          index - 1
-      else
+            index - 1
+        else
         # There's already a match, propagate the index without evaluating anything
-        index
-    ) (-1);
+          index
+      )
+      (-1);
 
   inherit (pep508) parseMarkers evalMarkers;
 
@@ -333,7 +334,7 @@ in
               )
             # Closing group, return stack
             else if token == ")" then
-              # Return a tuple of stack and next so the "(" branch above can know where the list is closed
+            # Return a tuple of stack and next so the "(" branch above can know where the list is closed
               [
                 stack
                 (i + 1)
@@ -495,14 +496,14 @@ in
         else
           (
             if match ".+\/.+" input != null then
-              # Input is a bare URL
+            # Input is a bare URL
               {
                 packageSegment = null;
                 url = input;
                 markerSegment = null;
               }
             else
-              # Input is a package name
+            # Input is a package name
               {
                 packageSegment = input;
                 url = null;
@@ -541,7 +542,7 @@ in
             extras = [ ];
           }
         else
-          # Assert that either regex matched
+        # Assert that either regex matched
           assert m1 != null || m2 != null;
           {
             # Based on PEP-508 alone it's not clear whether names should be normalized or not.
@@ -780,8 +781,8 @@ in
             else
               comparators.${value.op}
           )
-          (evalMarkers environ value.lhs)
-          (evalMarkers environ value.rhs)
+            (evalMarkers environ value.lhs)
+            (evalMarkers environ value.rhs)
         )
       else if value.type == "boolOp" then
         boolOps.${value.op} (evalMarkers environ value.lhs) (evalMarkers environ value.rhs)

--- a/vendor/pyproject.nix/lib/pep621.nix
+++ b/vendor/pyproject.nix/lib/pep621.nix
@@ -1,9 +1,8 @@
-{
-  lib,
-  pep440,
-  pep508,
-  pep518,
-  ...
+{ lib
+, pep440
+, pep508
+, pep518
+, ...
 }:
 let
   inherit (builtins)
@@ -49,26 +48,32 @@ fix (_self: {
       }
   */
   parseDependencies =
-    {
-      pyproject,
-      extrasAttrPaths ? [ ],
-      extrasListPaths ? { },
-      groupsAttrPaths ? [ ],
-      groupsListPaths ? { },
+    { pyproject
+    , extrasAttrPaths ? [ ]
+    , extrasListPaths ? { }
+    , groupsAttrPaths ? [ ]
+    , groupsListPaths ? { }
+    ,
     }:
     let
       # Fold extras from all considered attributes into one set
       extras' =
-        (foldl' (acc: attr: acc // getAttrPath attr { } pyproject) (pyproject.project.optional-dependencies
-          or { }
-        ) extrasAttrPaths)
+        (foldl' (acc: attr: acc // getAttrPath attr { } pyproject)
+          (
+            pyproject.project.optional-dependencies
+              or { }
+          )
+          extrasAttrPaths)
         // filterAttrs (_: deps: length deps > 0) (
           mapAttrs' (path: attr: nameValuePair attr (getAttrPath path [ ] pyproject)) extrasListPaths
         );
 
       depGroups' =
-        (foldl' (acc: attr: acc // getAttrPath attr { } pyproject) (pyproject.dependency-groups or { }
-        ) groupsAttrPaths)
+        (foldl' (acc: attr: acc // getAttrPath attr { } pyproject)
+          (
+            pyproject.dependency-groups or { }
+          )
+          groupsAttrPaths)
         // filterAttrs (_: deps: length deps > 0) (
           mapAttrs' (path: attr: nameValuePair attr (getAttrPath path [ ] pyproject)) groupsListPaths
         );
@@ -82,18 +87,20 @@ fix (_self: {
       # PEP-735 dependency groups
       groups =
         let
-          groups' = mapAttrs (
-            _group:
-            concatMap (
-              x:
-              if isString x then
-                [ (pep508.parseString x) ]
-              else if isAttrs x then
-                groups'.${x.include-group}
-              else
-                throw "Unsupported dependency group: ${x}"
+          groups' = mapAttrs
+            (
+              _group:
+              concatMap (
+                x:
+                if isString x then
+                  [ (pep508.parseString x) ]
+                else if isAttrs x then
+                  groups'.${x.include-group}
+                else
+                  throw "Unsupported dependency group: ${x}"
+              )
             )
-          ) depGroups';
+            depGroups';
         in
         groups';
     };

--- a/vendor/pyproject.nix/lib/pip.nix
+++ b/vendor/pyproject.nix/lib/pip.nix
@@ -56,65 +56,65 @@ lib.fix (self: {
       );
       # Fold line continuations
       inherit
-        (
-          (foldl'
-            (
-              acc: l':
-              let
-                m = match "(.+) *\\\\" l';
-                continue = m != null;
-                l = stripStr (if continue then (head m) else l');
-              in
-              if continue then
-                {
-                  line = acc.line ++ [ l ];
-                  inherit (acc) lines;
-                }
-              else
-                {
-                  line = [ ];
-                  lines = acc.lines ++ [ (acc.line ++ [ l ]) ];
-                }
-            )
-            {
-              lines = [ ];
-              line = [ ];
-            }
-            lines'
+        ((foldl'
+          (
+            acc: l':
+            let
+              m = match "(.+) *\\\\" l';
+              continue = m != null;
+              l = stripStr (if continue then (head m) else l');
+            in
+            if continue then
+              {
+                line = acc.line ++ [ l ];
+                inherit (acc) lines;
+              }
+            else
+              {
+                line = [ ];
+                lines = acc.lines ++ [ (acc.line ++ [ l ]) ];
+              }
           )
-        )
+          {
+            lines = [ ];
+            line = [ ];
+          }
+          lines'
+        ))
         lines
         ;
 
     in
-    foldl' (
-      acc: l:
-      let
-        m = match "-(c|r) (.+)" (head l);
-      in
-      acc
-      ++ (
-        # Common case, parse string
-        if m == null then
-          [
-            {
-              requirement = pep508.parseString (head l);
-              flags = tail l;
-            }
-          ]
+    foldl'
+      (
+        acc: l:
+        let
+          m = match "-(c|r) (.+)" (head l);
+        in
+        acc
+        ++ (
+          # Common case, parse string
+          if m == null then
+            [
+              {
+                requirement = pep508.parseString (head l);
+                flags = tail l;
+              }
+            ]
 
-        # Don't support constraint files
-        else if (head m) == "c" then
-          throw "Unsupported flag: -c"
+          # Don't support constraint files
+          else if (head m) == "c" then
+            throw "Unsupported flag: -c"
 
-        # Recursive requirements.txt
-        else
-          (self.parseRequirementsTxt (
-            if root == null then
-              throw "When importing recursive requirements.txt requirements needs to be passed as a path"
-            else
-              root + "/${head (tail m)}"
-          ))
-      )
-    ) [ ] lines;
+          # Recursive requirements.txt
+          else
+            (self.parseRequirementsTxt (
+              if root == null then
+                throw "When importing recursive requirements.txt requirements needs to be passed as a path"
+              else
+                root + "/${head (tail m)}"
+            ))
+        )
+      ) [ ]
+      lines;
 })

--- a/vendor/pyproject.nix/lib/poetry.nix
+++ b/vendor/pyproject.nix/lib/poetry.nix
@@ -1,9 +1,8 @@
-{
-  lib,
-  pep440,
-  pep508,
-  pep518,
-  ...
+{ lib
+, pep440
+, pep508
+, pep518
+, ...
 }:
 
 lib.fix (
@@ -65,23 +64,23 @@ lib.fix (
           foldl'
             (
               state: v:
-              let
-                nonzero = state.nonzero || v != 0;
-              in
-              state
-              // {
-                release = state.release ++ [
-                  (
-                    if nonzero && !state.nonzero then
-                      (v + 1)
-                    else if nonzero then
-                      0
-                    else
-                      v
-                  )
-                ];
-                inherit nonzero;
-              }
+                let
+                  nonzero = state.nonzero || v != 0;
+                in
+                state
+                // {
+                  release = state.release ++ [
+                    (
+                      if nonzero && !state.nonzero then
+                        (v + 1)
+                      else if nonzero then
+                        0
+                      else
+                        v
+                    )
+                  ];
+                  inherit nonzero;
+                }
             )
             {
               release = [ ];
@@ -109,16 +108,18 @@ lib.fix (
     # ]
     normalizeDependendenciesToList =
       deps:
-      foldl' (
-        acc: name:
-        acc
-        ++ (
-          let
-            dep = deps.${name};
-          in
-          if typeOf dep == "list" then map (normalizeDep name) dep else [ (normalizeDep name dep) ]
-        )
-      ) [ ] (attrNames deps);
+      foldl'
+        (
+          acc: name:
+          acc
+          ++ (
+            let
+              dep = deps.${name};
+            in
+            if typeOf dep == "list" then map (normalizeDep name) dep else [ (normalizeDep name dep) ]
+          )
+        ) [ ]
+        (attrNames deps);
 
     dummyMarker = {
       type = "bool";
@@ -184,29 +185,29 @@ lib.fix (
     */
     translatePoetryProject =
       pyproject:
-      assert !(pyproject ? project);
-      let
-        inherit (pyproject.tool) poetry;
-      in
-      pyproject
-      // {
-        project =
-          {
-            inherit (poetry) name version description;
-            authors = map translateAuthor poetry.authors;
-            urls =
-              optionalAttrs (poetry ? homepage) { Homepage = poetry.homepage; }
-              // optionalAttrs (poetry ? repository) { Repository = poetry.repository; }
-              // optionalAttrs (poetry ? documentation) { Documentation = poetry.documentation; };
-          }
-          // optionalAttrs (poetry ? license) { license.text = poetry.license; }
-          // optionalAttrs (poetry ? maintainers) { maintainers = map translateAuthor poetry.maintainers; }
-          // optionalAttrs (poetry ? readme) { inherit (poetry) readme; }
-          // optionalAttrs (poetry ? keywords) { inherit (poetry) keywords; }
-          // optionalAttrs (poetry ? classifiers) { inherit (poetry) classifiers; }
-          // optionalAttrs (poetry ? scripts) { inherit (poetry) scripts; }
-          // optionalAttrs (poetry ? plugins) { entry-points = poetry.plugins; };
-      };
+        assert !(pyproject ? project);
+        let
+          inherit (pyproject.tool) poetry;
+        in
+        pyproject
+        // {
+          project =
+            {
+              inherit (poetry) name version description;
+              authors = map translateAuthor poetry.authors;
+              urls =
+                optionalAttrs (poetry ? homepage) { Homepage = poetry.homepage; }
+                // optionalAttrs (poetry ? repository) { Repository = poetry.repository; }
+                // optionalAttrs (poetry ? documentation) { Documentation = poetry.documentation; };
+            }
+            // optionalAttrs (poetry ? license) { license.text = poetry.license; }
+            // optionalAttrs (poetry ? maintainers) { maintainers = map translateAuthor poetry.maintainers; }
+            // optionalAttrs (poetry ? readme) { inherit (poetry) readme; }
+            // optionalAttrs (poetry ? keywords) { inherit (poetry) keywords; }
+            // optionalAttrs (poetry ? classifiers) { inherit (poetry) classifiers; }
+            // optionalAttrs (poetry ? scripts) { inherit (poetry) scripts; }
+            // optionalAttrs (poetry ? plugins) { entry-points = poetry.plugins; };
+        };
 
     /*
       Parse dependencies from pyproject.toml (Poetry edition).
@@ -231,9 +232,10 @@ lib.fix (
       dependencies = map parseDependency (
         normalizeDependendenciesToList (pyproject.tool.poetry.dependencies or { })
       );
-      extras = mapAttrs (
-        _: group: map parseDependency (normalizeDependendenciesToList group.dependencies)
-      ) pyproject.tool.poetry.group or { };
+      extras = mapAttrs
+        (
+          _: group: map parseDependency (normalizeDependendenciesToList group.dependencies)
+        ) pyproject.tool.poetry.group or { };
       build-systems = pep518.parseBuildSystems pyproject;
 
       # PEP-735 dependency groups
@@ -274,15 +276,17 @@ lib.fix (
             {
               op = "<";
               version = version // rec {
-                release = lib.imap0 (
-                  i: tok:
-                  if i >= segments - 1 then
-                    0
-                  else if i == segments - 2 then
-                    (tok + 1)
-                  else
-                    tok
-                ) version.release;
+                release = lib.imap0
+                  (
+                    i: tok:
+                      if i >= segments - 1 then
+                        0
+                      else if i == segments - 2 then
+                        (tok + 1)
+                      else
+                        tok
+                  )
+                  version.release;
                 str = concatStringsSep "." (map toString release); # Overwrite with upper bounds
               };
             }

--- a/vendor/pyproject.nix/lib/pypa.nix
+++ b/vendor/pyproject.nix/lib/pypa.nix
@@ -1,8 +1,7 @@
-{
-  lib,
-  pep600,
-  pep656,
-  ...
+{ lib
+, pep600
+, pep656
+, ...
 }:
 let
   inherit (builtins)
@@ -210,22 +209,22 @@ lib.fix (self: {
       # None is a wildcard compatible with any implementation
       (abiTag.implementation == "none" || abiTag.implementation == "any")
       ||
-        # implementation == sys.implementation.name
-        abiTag.implementation == implementation
+      # implementation == sys.implementation.name
+      abiTag.implementation == implementation
       ||
-        # The CPython stable ABI is abi3 as in the shared library suffix.
-        (abiTag.implementation == "abi" && implementation == "cpython")
+      # The CPython stable ABI is abi3 as in the shared library suffix.
+      (abiTag.implementation == "abi" && implementation == "cpython")
     )
     &&
-      # Check version
-      (
-        abiTag.version == null
-        || abiTag.version == sourceVersion.major
-        || (
-          hasPrefix sourceVersion.major abiTag.version
-          && ((toInt (sourceVersion.major + sourceVersion.minor)) == toInt abiTag.version)
-        )
-      );
+    # Check version
+    (
+      abiTag.version == null
+      || abiTag.version == sourceVersion.major
+      || (
+        hasPrefix sourceVersion.major abiTag.version
+        && ((toInt (sourceVersion.major + sourceVersion.minor)) == toInt abiTag.version)
+      )
+    );
 
   /*
     Check whether a platform tag is compatible with this python interpreter.
@@ -321,12 +320,12 @@ lib.fix (self: {
       # Python is a wildcard compatible with any implementation
       pythonTag.implementation == "python"
       ||
-        # implementation == sys.implementation.name
-        pythonTag.implementation == implementation
+      # implementation == sys.implementation.name
+      pythonTag.implementation == implementation
     )
     &&
-      # Check version
-      pythonTag.version == null
+    # Check version
+    pythonTag.version == null
     || pythonTag.version == sourceVersion.major
     || (
       hasPrefix sourceVersion.major pythonTag.version
@@ -383,38 +382,42 @@ lib.fix (self: {
     else
       let
         # Get sorting/filter criteria fields
-        withSortedTags = map (
-          file:
-          let
-            abiCompatible = self.isABITagCompatible python file.abiTag;
+        withSortedTags = map
+          (
+            file:
+            let
+              abiCompatible = self.isABITagCompatible python file.abiTag;
 
-            # Filter only compatible tags
-            languageTags = filter (self.isPythonTagCompatible python) file.languageTags;
-            # Extract the tag as a number. E.g. "37" is `toInt "37"` and "none"/"any" is 0
-            languageTags' = map (tag: if tag == "none" then 0 else toInt tag.version) languageTags;
+              # Filter only compatible tags
+              languageTags = filter (self.isPythonTagCompatible python) file.languageTags;
+              # Extract the tag as a number. E.g. "37" is `toInt "37"` and "none"/"any" is 0
+              languageTags' = map (tag: if tag == "none" then 0 else toInt tag.version) languageTags;
 
-          in
-          {
-            bestLanguageTag = head (sort (x: y: x > y) languageTags');
-            compatible =
-              abiCompatible
-              && length languageTags > 0
-              && lib.any (self.isPlatformTagCompatible platform python.stdenv.cc.libc) file.platformTags;
-            inherit file;
-          }
-        ) files;
+            in
+            {
+              bestLanguageTag = head (sort (x: y: x > y) languageTags');
+              compatible =
+                abiCompatible
+                && length languageTags > 0
+                && lib.any (self.isPlatformTagCompatible platform python.stdenv.cc.libc) file.platformTags;
+              inherit file;
+            }
+          )
+          files;
 
         # Only consider files compatible with this interpreter
         compatibleFiles = filter (file: file.compatible) withSortedTags;
 
         # Sort files based on their tags
-        sorted = sort (
-          x: y:
-          x.file.distribution > y.file.distribution
-          || x.file.version > y.file.version
-          || (x.file.buildTag != null && (y.file.buildTag == null || x.file.buildTag > y.file.buildTag))
-          || x.bestLanguageTag > y.bestLanguageTag
-        ) compatibleFiles;
+        sorted = sort
+          (
+            x: y:
+              x.file.distribution > y.file.distribution
+              || x.file.version > y.file.version
+              || (x.file.buildTag != null && (y.file.buildTag == null || x.file.buildTag > y.file.buildTag))
+              || x.bestLanguageTag > y.bestLanguageTag
+          )
+          compatibleFiles;
 
       in
       # Strip away temporary sorting metadata


### PR DESCRIPTION
Decreasing the dependencies, and making the flake easier to work with overall. I recognize that this is unmaintained, but it's still a dependency for a lot of projects - so losing the unnecessary `flake-utils` and `nix-systems` will be good for decreasing `flake.lock` bloat.