### PR TITLE
fix: python tag in predicted wheel URLs

### DIFF
--- a/fetchers/default.nix
+++ b/fetchers/default.nix
@@ -4,7 +4,7 @@
 , pyproject-nix
 }:
 let
-  inherit (builtins) substring elemAt;
+  inherit (builtins) substring elemAt length;
   inherit (lib) toLower;
 
   inherit (pyproject-nix.lib.pypa) matchWheelFileName;
@@ -27,7 +27,7 @@ let
       matchedWheel = matchWheelFileName file;
       matchedEgg = matchEggFileName file;
       kind =
-        if matchedWheel != null then "wheel"
+        if matchedWheel != null then elemAt matchedWheel (length matchedWheel - 3)
         else if matchedEgg != null then elemAt matchedEgg 2
         else "source";
     in


### PR DESCRIPTION
**Partially fixes #1920:** fetches wheels from valid predicted URLs for most packages.

Still fails to fetch some weird wheels, e.g. [DAWG-Python](https://pypi.org/project/DAWG-Python/#DAWG_Python-0.7.2-py2.py3-none-any.whl), because of issue curl/curl#17554 fixed in curl 8.15 that is going to be merged into nixpkgs in NixOS/nixpkgs#425701.

[Contribution](https://github.com/nix-community/poetry2nix/blob/master/README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](https://github.com/nix-community/poetry2nix/blob/master/tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"