### PR TITLE
chore: update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,17 +40,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730157240,
-        "narHash": "sha256-P8wF4ag6Srmpb/gwskYpnIsnspbjZlRvu47iN527ABQ=",
+        "lastModified": 1759281824,
+        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75e28c029ef2605f9841e0baa335d70065fe7ae2",
+        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
-        "rev": "75e28c029ef2605f9841e0baa335d70065fe7ae2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    # Last working commit from nixos-small-unstable
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=75e28c029ef2605f9841e0baa335d70065fe7ae2";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
A version of nixpkgs has now been released that contains the commit that poetry2nix was pinned to earlier.

I'm curious if CI will also show the "`rustPlatform.fetchCargoTarball` has been removed in 25.05, use `rustPlatform.fetchCargoVendor` instead" issue that I'm seeing trying to build
https://github.com/MaibornWolff/SecObserve/tree/dev/backend

[Contribution](https://github.com/nix-community/poetry2nix/blob/master/README.md#contributing) checklist (recommended but not always applicable/required):

- [x] There's an _[automated test](https://github.com/nix-community/poetry2nix/blob/master/tests/default.nix)_ for this change
- [x] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [x] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
