### PR TITLE
chore: update vendored pyproject.nix

### DIFF
--- a/vendor/pyproject.nix/default.nix
+++ b/vendor/pyproject.nix/default.nix
@@ -5,4 +5,9 @@ lib.fix (self: {
     pyproject-nix = self;
     inherit lib;
   };
+  packages =
+    { callPackage }:
+    {
+      build-editable = callPackage ./build/editable { };
+    };
 })

--- a/vendor/pyproject.nix/lib/default.nix
+++ b/vendor/pyproject.nix/lib/default.nix
@@ -11,6 +11,7 @@ fix (
     pypa = ./pypa.nix;
     project = ./project.nix;
     renderers = ./renderers.nix;
+    util = ./util.nix;
     validators = ./validators.nix;
     scripts = ./scripts.nix;
     poetry = ./poetry.nix;

--- a/vendor/pyproject.nix/lib/lib.nix
+++ b/vendor/pyproject.nix/lib/lib.nix
@@ -1,0 +1,24 @@
+# Small utilities for internal reuse, not exposed externally
+{ lib }:
+let
+  inherit (builtins)
+    filter
+    match
+    split
+    head
+    ;
+  inherit (lib) isString;
+
+in
+rec {
+  isEmptyStr = s: isString s && match " *" s == null;
+
+  splitComma = s: if s == "" then [ ] else filter isEmptyStr (split " *, *" s);
+
+  stripStr =
+    s:
+    let
+      t = match "[\t ]*(.*[^\t ])[\t ]*" s;
+    in
+    if t == null then "" else head t;
+}

--- a/vendor/pyproject.nix/lib/pep440.nix
+++ b/vendor/pyproject.nix/lib/pep440.nix
@@ -18,7 +18,7 @@ let
     sublist
     findFirst
     ;
-  inherit (import ./util.nix { inherit lib; }) splitComma;
+  inherit (import ./lib.nix { inherit lib; }) splitComma;
 
   # A version of lib.toInt that supports leading zeroes
   toIntRelease =
@@ -271,7 +271,13 @@ fix (self: {
         }
       ]
   */
-  parseVersionConds = conds: map self.parseVersionCond (splitComma conds);
+  parseVersionConds =
+    conds:
+    let
+      # If the conditions are surrounded by parens strip them away
+      parenM = match "\\((.+)\\)" conds;
+    in
+    map self.parseVersionCond (splitComma (if parenM != null then head parenM else conds));
 
   /*
     Compare two versions as parsed by `parseVersion` according to PEP-440.

--- a/vendor/pyproject.nix/lib/pep508.nix
+++ b/vendor/pyproject.nix/lib/pep508.nix
@@ -37,7 +37,7 @@ let
     take
     toInt
     ;
-  inherit (import ./util.nix { inherit lib; }) splitComma stripStr;
+  inherit (import ./lib.nix { inherit lib; }) splitComma stripStr;
 
   # Marker fields + their parsers
   markerFields =
@@ -737,7 +737,14 @@ in
           throw "Unsupported platform";
       platform_version = ""; # Field not reproducible
       python_version = python.passthru.pythonVersion;
-      python_full_version = python.version;
+      # Nixpkgs lacks an equivalent of python_full_version.
+      # This isn't a problem on CPython where we can use python.version to get the full version,
+      # but on pypy we don't know which language patch version of Python the interpreter is for.
+      python_full_version =
+        if lib.hasPrefix python.passthru.pythonVersion python.version then
+          python.version
+        else
+          python.passthru.pythonVersion;
       implementation_name = python.passthru.implementation;
       implementation_version = python.version;
     };

--- a/vendor/pyproject.nix/lib/pep599.nix
+++ b/vendor/pyproject.nix/lib/pep599.nix
@@ -14,8 +14,9 @@ _:
     i686 = "i686";
     aarch64 = "aarch64";
     armv7l = "armv7l";
-    ppc64 = "powerpc64";
-    ppc64le = "powerpc64le";
+    powerpc64 = "ppc64";
+    powerpc64le = "ppc64le";
     s390x = "s390x";
+    riscv64 = "riscv64";
   };
 }

--- a/vendor/pyproject.nix/lib/pep600.nix
+++ b/vendor/pyproject.nix/lib/pep600.nix
@@ -5,8 +5,20 @@ let
     elemAt
     compareVersions
     splitVersion
+    listToAttrs
+    attrNames
     ;
   inherit (lib) fix;
+
+  # Flip key/value positions in pep599.manyLinuxTargetMachines.
+  # When checking wheel compatibility we want to run the lookup in the opposite order,
+  # going _from_ a Python-native arch like ppc64le _to_ a nixpkgs value like powerpc64le.
+  targetMachines' = listToAttrs (
+    map (name: {
+      value = name;
+      name = pep599.manyLinuxTargetMachines.${name};
+    }) (attrNames pep599.manyLinuxTargetMachines)
+  );
 
 in
 fix (self: {
@@ -69,7 +81,7 @@ fix (self: {
       false
     else if compareVersions "${sysMajor}.${sysMinor}" "${tagMajor}.${tagMinor}" < 0 then
       false
-    else if pep599.manyLinuxTargetMachines.${tagArch} != platform.parsed.cpu.name then
+    else if (targetMachines'.${tagArch} or tagArch) != platform.parsed.cpu.name then
       false
     else
       true;

--- a/vendor/pyproject.nix/lib/pip.nix
+++ b/vendor/pyproject.nix/lib/pip.nix
@@ -13,7 +13,7 @@ let
     hasContext
     unsafeDiscardStringContext
     ;
-  inherit (import ./util.nix { inherit lib; }) stripStr;
+  inherit (import ./lib.nix { inherit lib; }) stripStr;
 
   uncomment = l: head (match " *([^#]*).*" l);
 
@@ -42,11 +42,7 @@ lib.fix (self: {
       #
       # We also need to support stringly paths...
       isPath = typeOf requirements == "path" || hasContext requirements;
-      path' =
-        if typeOf requirements == "path" then
-          requirements
-        else
-          /. + unsafeDiscardStringContext requirements;
+      path' = if isPath then requirements else /. + unsafeDiscardStringContext requirements;
       root = dirOf path';
 
       # Requirements without comments and no empty strings

--- a/vendor/pyproject.nix/lib/poetry.nix
+++ b/vendor/pyproject.nix/lib/poetry.nix
@@ -3,6 +3,7 @@
   pep440,
   pep508,
   pep518,
+  pypa,
   ...
 }:
 
@@ -24,7 +25,7 @@ lib.fix (
       concatStringsSep
       ;
     inherit (lib) optionalAttrs concatLists;
-    inherit (import ./util.nix { inherit lib; }) splitComma;
+    inherit (import ./lib.nix { inherit lib; }) splitComma;
 
     # Translate author from a string like "Name <email>" to a structured set as defined by PEP-621.
     translateAuthor =
@@ -160,7 +161,7 @@ lib.fix (
 
       in
       {
-        inherit (dep) name;
+        name = pypa.normalizePackageName dep.name;
         conditions = if dep ? version then self.parseVersionConds dep.version else [ ];
         extras = dep.extras or [ ];
         url = dep.url or null;
@@ -190,22 +191,21 @@ lib.fix (
       in
       pyproject
       // {
-        project =
-          {
-            inherit (poetry) name version description;
-            authors = map translateAuthor poetry.authors;
-            urls =
-              optionalAttrs (poetry ? homepage) { Homepage = poetry.homepage; }
-              // optionalAttrs (poetry ? repository) { Repository = poetry.repository; }
-              // optionalAttrs (poetry ? documentation) { Documentation = poetry.documentation; };
-          }
-          // optionalAttrs (poetry ? license) { license.text = poetry.license; }
-          // optionalAttrs (poetry ? maintainers) { maintainers = map translateAuthor poetry.maintainers; }
-          // optionalAttrs (poetry ? readme) { inherit (poetry) readme; }
-          // optionalAttrs (poetry ? keywords) { inherit (poetry) keywords; }
-          // optionalAttrs (poetry ? classifiers) { inherit (poetry) classifiers; }
-          // optionalAttrs (poetry ? scripts) { inherit (poetry) scripts; }
-          // optionalAttrs (poetry ? plugins) { entry-points = poetry.plugins; };
+        project = {
+          inherit (poetry) name version description;
+          authors = map translateAuthor poetry.authors;
+          urls =
+            optionalAttrs (poetry ? homepage) { Homepage = poetry.homepage; }
+            // optionalAttrs (poetry ? repository) { Repository = poetry.repository; }
+            // optionalAttrs (poetry ? documentation) { Documentation = poetry.documentation; };
+        }
+        // optionalAttrs (poetry ? license) { license.text = poetry.license; }
+        // optionalAttrs (poetry ? maintainers) { maintainers = map translateAuthor poetry.maintainers; }
+        // optionalAttrs (poetry ? readme) { inherit (poetry) readme; }
+        // optionalAttrs (poetry ? keywords) { inherit (poetry) keywords; }
+        // optionalAttrs (poetry ? classifiers) { inherit (poetry) classifiers; }
+        // optionalAttrs (poetry ? scripts) { inherit (poetry) scripts; }
+        // optionalAttrs (poetry ? plugins) { entry-points = poetry.plugins; };
       };
 
     /*

--- a/vendor/pyproject.nix/lib/util.nix
+++ b/vendor/pyproject.nix/lib/util.nix
@@ -1,24 +1,60 @@
-# Small utilities for internal reuse, not exposed externally
-{ lib }:
+{
+  pep440,
+  lib,
+  ...
+}:
 let
-  inherit (builtins)
-    filter
-    match
-    split
-    head
-    ;
-  inherit (lib) isString;
-
+  inherit (builtins) all attrNames concatMap;
+  inherit (lib) hasSuffix;
 in
-rec {
-  isEmptyStr = s: isString s && match " *" s == null;
+{
+  /**
+    Filter Python interpreter derivations from an attribute set based on
+    python-requires constraints.
 
-  splitComma = s: if s == "" then [ ] else filter isEmptyStr (split " *, *" s);
+    # Example:
+    ```nix
+    util.filterPythonInterpreters {
+      requires = pep440.parseVersionConds ">=3.12";
+      inherit (pkgs) pythonInterpreters;
+    }
+    ->
+    [
+      «derivation /nix/store/5iwwrbr1dh1yc63gmz1alsk1d96jgfjy-python3-3.12.11.drv»
+      «derivation /nix/store/6p8y1zwm68kksdrad12ybn7lrvvpgwc5-python3-3.13.8.drv»
+      «derivation /nix/store/fvac8j3h7sxqfaw7hllr9cllns34pgcm-python3-3.14.0.drv»
+    ]
+    ```
+  */
 
-  stripStr =
-    s:
-    let
-      t = match "[\t ]*(.*[^\t ])[\t ]*" s;
-    in
-    if t == null then "" else head t;
+  filterPythonInterpreters =
+    {
+      requires-python,
+      pythonInterpreters,
+      pre ? false,
+      implementation ? "cpython",
+    }:
+    concatMap (
+      name:
+      let
+        drv = pythonInterpreters.${name};
+        version = pep440.parseVersion drv.version;
+        pythonVersion = pep440.parseVersion drv.pythonVersion;
+      in
+      if
+        (
+          name != "override"
+          && name != "overrideDerivation"
+          &&
+            # Filter prebuilt pypy derivations & python3Minimal
+            !(hasSuffix "prebuilt" name || hasSuffix "Minimal" name)
+          && (drv.implementation or "") == implementation
+          && (pre || version.pre == null)
+          && all (cond: pep440.comparators.${cond.op} pythonVersion cond.version) requires-python
+        )
+      then
+        [ drv ]
+      else
+        [ ]
+    ) (attrNames pythonInterpreters);
 }


### PR DESCRIPTION
Updates the vendored pyproject.nix to the latest version, which includes:

- riscv64 support in manyLinuxTargetMachines (pep599.nix)
- Simplified parseABITag that handles all ABI tags including those with underscores like 'graalpy242_311_native' (pypa.nix)
- Various documentation and code improvements

This fixes wheel compatibility checking for RISC-V builds and GraalPy interpreters.

